### PR TITLE
Fix issue 37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [UNRELEASED]
+### Fixed
+- with recent versions of GCC, compilation issue with lexx and yacc produced source code.
+
+### Updated
+- `gnulib` in now built from a stable branch, `stable-202307`
+
 # [2.5.1]
 - adding `-S` option flag for `p11keygen`, for enabling key generation when logged in as Security Officer (PR #33)
 - fixed a few memory management issues, preventing to import EC public keys when using `p11keygen`, `p11unwrap` and `p11importpubk`.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -59,7 +59,7 @@ autoreconf -vfi
 
 cat <<EOF
 ========================================================================
-Bootstrap complete. 
+Bootstrap complete.
 Execute './configure' and 'make' to build the project.
 
 EOF

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -12,7 +12,7 @@ In order to build the project from scratch, you will need
    ```sh
    $ sudo apt-get install gcc make perl
    ```
- - the autotools suite: `autoconf`, `automake`, `libtool`, and `autoconf-archive`, as well as `pkg-config`.
+ - the autotools suite: `autoconf`, `automake`>=1.14, `libtool`, and `autoconf-archive`, as well as `pkg-config`.
    If your host is Debian-based (e.g. Ubuntu), you can execute the following command:
    ```sh
    $ sudo apt-get install autoconf-archive autoconf automake libtool pkg-config

--- a/lib/attribctx_lexer.c
+++ b/lib/attribctx_lexer.c
@@ -1,4 +1,5 @@
-#line 2 "attribctx_lexer.c"
+#line 1 "attribctx_lexer.c"
+#include <config.h>
 
 #line 4 "attribctx_lexer.c"
 
@@ -8,11 +9,17 @@
 
 #define yy_create_buffer cl_create_buffer
 #define yy_delete_buffer cl_delete_buffer
-#define yy_flex_debug cl_flex_debug
+#define yy_scan_buffer cl_scan_buffer
+#define yy_scan_string cl_scan_string
+#define yy_scan_bytes cl_scan_bytes
 #define yy_init_buffer cl_init_buffer
 #define yy_flush_buffer cl_flush_buffer
 #define yy_load_buffer_state cl_load_buffer_state
 #define yy_switch_to_buffer cl_switch_to_buffer
+#define yypush_buffer_state clpush_buffer_state
+#define yypop_buffer_state clpop_buffer_state
+#define yyensure_buffer_stack clensure_buffer_stack
+#define yy_flex_debug cl_flex_debug
 #define yyin clin
 #define yyleng clleng
 #define yylex cllex
@@ -27,23 +34,247 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 37
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
 
-/* First, we deal with  platform-specific or compiler-specific issues. */
-
-#if defined(__FreeBSD__)
-#ifndef __STDC_LIMIT_MACROS
-#define	__STDC_LIMIT_MACROS
-#endif
-#include <sys/cdefs.h>
-#include <stdint.h>
+#ifdef yy_create_buffer
+#define cl_create_buffer_ALREADY_DEFINED
 #else
-#define	__dead2
+#define yy_create_buffer cl_create_buffer
 #endif
+
+#ifdef yy_delete_buffer
+#define cl_delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer cl_delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define cl_scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer cl_scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define cl_scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string cl_scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define cl_scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes cl_scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define cl_init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer cl_init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define cl_flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer cl_flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define cl_load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state cl_load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define cl_switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer cl_switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define clpush_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state clpush_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define clpop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state clpop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define clensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack clensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define cllex_ALREADY_DEFINED
+#else
+#define yylex cllex
+#endif
+
+#ifdef yyrestart
+#define clrestart_ALREADY_DEFINED
+#else
+#define yyrestart clrestart
+#endif
+
+#ifdef yylex_init
+#define cllex_init_ALREADY_DEFINED
+#else
+#define yylex_init cllex_init
+#endif
+
+#ifdef yylex_init_extra
+#define cllex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra cllex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define cllex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy cllex_destroy
+#endif
+
+#ifdef yyget_debug
+#define clget_debug_ALREADY_DEFINED
+#else
+#define yyget_debug clget_debug
+#endif
+
+#ifdef yyset_debug
+#define clset_debug_ALREADY_DEFINED
+#else
+#define yyset_debug clset_debug
+#endif
+
+#ifdef yyget_extra
+#define clget_extra_ALREADY_DEFINED
+#else
+#define yyget_extra clget_extra
+#endif
+
+#ifdef yyset_extra
+#define clset_extra_ALREADY_DEFINED
+#else
+#define yyset_extra clset_extra
+#endif
+
+#ifdef yyget_in
+#define clget_in_ALREADY_DEFINED
+#else
+#define yyget_in clget_in
+#endif
+
+#ifdef yyset_in
+#define clset_in_ALREADY_DEFINED
+#else
+#define yyset_in clset_in
+#endif
+
+#ifdef yyget_out
+#define clget_out_ALREADY_DEFINED
+#else
+#define yyget_out clget_out
+#endif
+
+#ifdef yyset_out
+#define clset_out_ALREADY_DEFINED
+#else
+#define yyset_out clset_out
+#endif
+
+#ifdef yyget_leng
+#define clget_leng_ALREADY_DEFINED
+#else
+#define yyget_leng clget_leng
+#endif
+
+#ifdef yyget_text
+#define clget_text_ALREADY_DEFINED
+#else
+#define yyget_text clget_text
+#endif
+
+#ifdef yyget_lineno
+#define clget_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno clget_lineno
+#endif
+
+#ifdef yyset_lineno
+#define clset_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno clset_lineno
+#endif
+
+#ifdef yywrap
+#define clwrap_ALREADY_DEFINED
+#else
+#define yywrap clwrap
+#endif
+
+#ifdef yyalloc
+#define clalloc_ALREADY_DEFINED
+#else
+#define yyalloc clalloc
+#endif
+
+#ifdef yyrealloc
+#define clrealloc_ALREADY_DEFINED
+#else
+#define yyrealloc clrealloc
+#endif
+
+#ifdef yyfree
+#define clfree_ALREADY_DEFINED
+#else
+#define yyfree clfree
+#endif
+
+#ifdef yytext
+#define cltext_ALREADY_DEFINED
+#else
+#define yytext cltext
+#endif
+
+#ifdef yyleng
+#define clleng_ALREADY_DEFINED
+#else
+#define yyleng clleng
+#endif
+
+#ifdef yyin
+#define clin_ALREADY_DEFINED
+#else
+#define yyin clin
+#endif
+
+#ifdef yyout
+#define clout_ALREADY_DEFINED
+#else
+#define yyout clout
+#endif
+
+#ifdef yy_flex_debug
+#define cl_flex_debug_ALREADY_DEFINED
+#else
+#define yy_flex_debug cl_flex_debug
+#endif
+
+#ifdef yylineno
+#define cllineno_ALREADY_DEFINED
+#else
+#define yylineno cllineno
+#endif
+
+/* First, we deal with  platform-specific or compiler-specific issues. */
 
 /* begin standard C headers. */
 #include <stdio.h>
@@ -114,65 +345,61 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE clrestart(clin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 /* The state buf must be large enough to hold one state per character in the main buffer.
@@ -189,43 +416,49 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t clleng;
+extern int yyleng;
 
-extern FILE *clin, *clout;
+extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     /* Note: We specifically omit the test for yy_rule_can_match_eol because it requires
      *       access to the local variable yy_act. Since yyless() is a macro, it would break
-     *       existing scanners that call yyless() from OUTSIDE cllex. 
+     *       existing scanners that call yyless() from OUTSIDE yylex.
      *       One obvious solution it to make yy_act a global. I tried that, and saw
-     *       a 5% performance hit in a non-cllineno scanner, because yy_act is
+     *       a 5% performance hit in a non-yylineno scanner, because yy_act is
      *       normally declared as a register variable-- so it is not worth it.
      */
     #define  YY_LESS_LINENO(n) \
             do { \
                 int yyl;\
-                for ( yyl = n; yyl < clleng; ++yyl )\
-                    if ( cltext[yyl] == '\n' )\
-                        --cllineno;\
+                for ( yyl = n; yyl < yyleng; ++yyl )\
+                    if ( yytext[yyl] == '\n' )\
+                        --yylineno;\
+            }while(0)
+    #define YY_LINENO_REWIND_TO(dst) \
+            do {\
+                const char *p;\
+                for ( p = yy_cp-1; p >= (dst); --p)\
+                    if ( *p == '\n' )\
+                        --yylineno;\
             }while(0)
     
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up cltext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		*yy_cp = (yy_hold_char); \
 		YY_RESTORE_YY_MORE_OFFSET \
 		(yy_c_buf_p) = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
-		YY_DO_BEFORE_ACTION; /* set up cltext again */ \
+		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -240,12 +473,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -268,7 +501,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -285,8 +518,8 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via clrestart()), so that the user can continue scanning by
-	 * just pointing clin at a new input file.
+	 * (via yyrestart()), so that the user can continue scanning by
+	 * just pointing yyin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
 
@@ -296,7 +529,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -308,106 +541,101 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
 #define yy_current_buffer YY_CURRENT_BUFFER
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE (yy_buffer_stack)[(yy_buffer_stack_top)]
 
-/* yy_hold_char holds the character lost when cltext is formed. */
+/* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t clleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
-/* Flag which is used to allow clwrap()'s to do buffer switches
- * instead of setting up a fresh clin.  A bit of a hack ...
+/* Flag which is used to allow yywrap()'s to do buffer switches
+ * instead of setting up a fresh yyin.  A bit of a hack ...
  */
 static int yy_did_buffer_switch_on_eof;
 
-void clrestart (FILE *input_file  );
-void cl_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE cl_create_buffer (FILE *file,int size  );
-void cl_delete_buffer (YY_BUFFER_STATE b  );
-void cl_flush_buffer (YY_BUFFER_STATE b  );
-void clpush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void clpop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void clensure_buffer_stack (void );
-static void cl_load_buffer_state (void );
-static void cl_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER cl_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE cl_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE cl_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE cl_scan_bytes (yyconst char *bytes,yy_size_t len  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
-void *clalloc (yy_size_t  );
-void *clrealloc (void *,yy_size_t  );
-void clfree (void *  );
-
-#define yy_new_buffer cl_create_buffer
-
+#define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        clensure_buffer_stack (); \
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            cl_create_buffer(clin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        clensure_buffer_stack (); \
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            cl_create_buffer(clin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
 
-#define clwrap() 1
+#define clwrap() (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *clin = (FILE *) 0, *clout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
-extern int cllineno;
+extern int yylineno;
+int yylineno = 1;
 
-int cllineno = 1;
+extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
+#define yytext_ptr yytext
 
-extern char *cltext;
-#define yytext_ptr cltext
-
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-static void yy_fatal_error (yyconst char msg[]  ) __dead2;
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
- * corresponding action - sets up cltext.
+ * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	clleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 72
 #define YY_END_OF_BUFFER 73
 /* This struct is not used in this scanner,
@@ -417,7 +645,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[869] =
+static const flex_int16_t yy_accept[869] =
     {   0,
         0,    0,    0,    0,   73,   71,   67,   67,    5,    2,
        66,   65,   71,   68,   71,   71,   71,   71,   71,   71,
@@ -516,7 +744,7 @@ static yyconst flex_int16_t yy_accept[869] =
         0,    0,    0,    0,   32,   59,   34,    0
     } ;
 
-static yyconst flex_int32_t yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    2,    1,    1,    1,    1,    1,    1,    1,
@@ -548,7 +776,7 @@ static yyconst flex_int32_t yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int32_t yy_meta[69] =
+static const YY_CHAR yy_meta[69] =
     {   0,
         1,    1,    2,    1,    3,    1,    4,    4,    4,    4,
         4,    4,    4,    4,    4,    1,    5,    5,    5,    5,
@@ -559,7 +787,7 @@ static yyconst flex_int32_t yy_meta[69] =
         6,    6,    6,    6,    7,    6,    1,    1
     } ;
 
-static yyconst flex_int16_t yy_base[875] =
+static const flex_int16_t yy_base[875] =
     {   0,
         0, 1677, 1675, 1674, 1674, 1718,   67,   69, 1718, 1718,
        33,   67,   76, 1718,   71,   73,   86,   92,   76,   76,
@@ -659,7 +887,7 @@ static yyconst flex_int16_t yy_base[875] =
      1697, 1704, 1708, 1710
     } ;
 
-static yyconst flex_int16_t yy_def[875] =
+static const flex_int16_t yy_def[875] =
     {   0,
       868,    1,  869,  869,  868,  868,  868,  868,  868,  868,
       870,  868,  868,  868,  868,  868,  868,  868,  868,  868,
@@ -759,7 +987,7 @@ static yyconst flex_int16_t yy_def[875] =
       868,  868,  868,  868
     } ;
 
-static yyconst flex_int16_t yy_nxt[1787] =
+static const flex_int16_t yy_nxt[1787] =
     {   0,
         6,    7,    8,    9,   10,    6,   11,   12,   13,   13,
        13,   13,   13,   13,   13,   14,   15,    6,   16,   17,
@@ -959,7 +1187,7 @@ static yyconst flex_int16_t yy_nxt[1787] =
       868,  868,  868,  868,  868,  868
     } ;
 
-static yyconst flex_int16_t yy_chk[1787] =
+static const flex_int16_t yy_chk[1787] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -1160,7 +1388,7 @@ static yyconst flex_int16_t yy_chk[1787] =
     } ;
 
 /* Table of booleans, true if rule could match eol. */
-static yyconst flex_int32_t yy_rule_can_match_eol[73] =
+static const flex_int32_t yy_rule_can_match_eol[73] =
     {   0,
 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
@@ -1170,8 +1398,8 @@ static yyconst flex_int32_t yy_rule_can_match_eol[73] =
 static yy_state_type yy_last_accepting_state;
 static char *yy_last_accepting_cpos;
 
-extern int cl_flex_debug;
-int cl_flex_debug = 0;
+extern int yy_flex_debug;
+int yy_flex_debug = 0;
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -1180,7 +1408,7 @@ int cl_flex_debug = 0;
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-char *cltext;
+char *yytext;
 #line 1 "attribctx_lexer.l"
 /* attributes lexical analyser */
 /*
@@ -1199,14 +1427,15 @@ char *cltext;
  * limitations under the License.
  */
 /* %option debug */
-#line 27 "attribctx_lexer.l"
-#include "config.h"
+
+#line 31 "attribctx_lexer.l"
 #include <stdarg.h>
 #include "pkcs11lib.h"
 #include "attribctx_parser.h"
 
+#line 1436 "attribctx_lexer.c"
 
-#line 1210 "attribctx_lexer.c"
+#line 1438 "attribctx_lexer.c"
 
 #define INITIAL 0
 #define STR 1
@@ -1223,36 +1452,36 @@ char *cltext;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int cllex_destroy (void );
+int yylex_destroy ( void );
 
-int clget_debug (void );
+int yyget_debug ( void );
 
-void clset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE clget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void clset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *clget_in (void );
+FILE *yyget_in ( void );
 
-void clset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *clget_out (void );
+FILE *yyget_out ( void );
 
-void clset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t clget_leng (void );
+			int yyget_leng ( void );
 
-char *clget_text (void );
+char *yyget_text ( void );
 
-int clget_lineno (void );
+int yyget_lineno ( void );
 
-void clset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -1260,37 +1489,43 @@ void clset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int clwrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int clwrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
-    static void yyunput (int c,char *buf_ptr  );
-#endif
     
+    static void yyunput ( int c, char *buf_ptr  );
+    
+#endif
+
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Copy whatever the last rule matched to the standard output. */
@@ -1298,7 +1533,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( cltext, clleng, 1, clout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -1309,20 +1544,20 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
-			     (c = getc( clin )) != EOF && c != '\n'; ++n ) \
+			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
 		if ( c == '\n' ) \
 			buf[n++] = (char) c; \
-		if ( c == EOF && ferror( clin ) ) \
+		if ( c == EOF && ferror( yyin ) ) \
 			YY_FATAL_ERROR( "input in flex scanner failed" ); \
 		result = n; \
 		} \
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, clin))==0 && ferror(clin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -1330,7 +1565,7 @@ static int input (void );
 				break; \
 				} \
 			errno=0; \
-			clearerr(clin); \
+			clearerr(yyin); \
 			} \
 		}\
 \
@@ -1363,12 +1598,12 @@ static int input (void );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int cllex (void);
+extern int yylex (void);
 
-#define YY_DECL int cllex (void)
+#define YY_DECL int yylex (void)
 #endif /* !YY_DECL */
 
-/* Code executed at the beginning of each rule, after cltext and clleng
+/* Code executed at the beginning of each rule, after yytext and yyleng
  * have been set up.
  */
 #ifndef YY_USER_ACTION
@@ -1377,13 +1612,13 @@ extern int cllex (void);
 
 /* Code executed at the end of each rule. */
 #ifndef YY_BREAK
-#define YY_BREAK break;
+#define YY_BREAK /*LINTED*/break;
 #endif
 
 #define YY_RULE_SETUP \
-	if ( clleng > 0 ) \
+	if ( yyleng > 0 ) \
 		YY_CURRENT_BUFFER_LVALUE->yy_at_bol = \
-				(cltext[clleng - 1] == '\n'); \
+				(yytext[yyleng - 1] == '\n'); \
 	YY_USER_ACTION
 
 /** The main scanner function which does all the work.
@@ -1394,11 +1629,6 @@ YY_DECL
 	char *yy_cp, *yy_bp;
 	int yy_act;
     
-#line 35 "attribctx_lexer.l"
-
-
-#line 1401 "attribctx_lexer.c"
-
 	if ( !(yy_init) )
 		{
 		(yy_init) = 1;
@@ -1410,26 +1640,32 @@ YY_DECL
 		if ( ! (yy_start) )
 			(yy_start) = 1;	/* first start state */
 
-		if ( ! clin )
-			clin = stdin;
+		if ( ! yyin )
+			yyin = stdin;
 
-		if ( ! clout )
-			clout = stdout;
+		if ( ! yyout )
+			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			clensure_buffer_stack ();
+			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				cl_create_buffer(clin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		cl_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
-	while ( 1 )		/* loops until end-of-file is reached */
+	{
+#line 38 "attribctx_lexer.l"
+
+
+#line 1662 "attribctx_lexer.c"
+
+	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
-		/* Support of cltext. */
+		/* Support of yytext. */
 		*yy_cp = (yy_hold_char);
 
 		/* yy_bp points to the position in yy_ch_buf of the start of
@@ -1452,9 +1688,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 869 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_current_state != 868 );
@@ -1468,11 +1704,11 @@ yy_find_action:
 
 		if ( yy_act != YY_END_OF_BUFFER && yy_rule_can_match_eol[yy_act] )
 			{
-			yy_size_t yyl;
-			for ( yyl = 0; yyl < clleng; ++yyl )
-				if ( cltext[yyl] == '\n' )
-					   
-    cllineno++;
+			int yyl;
+			for ( yyl = 0; yyl < yyleng; ++yyl )
+				if ( yytext[yyl] == '\n' )
+					
+    yylineno++;
 ;
 			}
 
@@ -1489,27 +1725,27 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 37 "attribctx_lexer.l"
+#line 40 "attribctx_lexer.l"
 { /* skipping comment */ }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 39 "attribctx_lexer.l"
+#line 42 "attribctx_lexer.l"
 { cllval.val_str.len=0; BEGIN(STR); }
 	YY_BREAK
 case 3:
 /* rule 3 can match eol */
 YY_RULE_SETUP
-#line 40 "attribctx_lexer.l"
+#line 43 "attribctx_lexer.l"
 { cllval.val_str.val = strdup(cltext); cllval.val_str.len = strlen(cltext); }
 	YY_BREAK
 case YY_STATE_EOF(STR):
-#line 41 "attribctx_lexer.l"
+#line 44 "attribctx_lexer.l"
 { clerror(NULL, "Unterminated quoted string"); yyterminate(); }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 42 "attribctx_lexer.l"
+#line 45 "attribctx_lexer.l"
 {   /* special case: if we have an empty string, regular rule is never executed */
 		/* in which case, we perform the empty string assignment from here */
     if (cllval.val_str.len==0) { cllval.val_str.val=strdup(""); } BEGIN(INITIAL); return STRING;
@@ -1517,292 +1753,292 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 47 "attribctx_lexer.l"
+#line 50 "attribctx_lexer.l"
 { return NO; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 48 "attribctx_lexer.l"
+#line 51 "attribctx_lexer.l"
 { cllval.ckattr = CKA_ID; return CKATTR_STR; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 49 "attribctx_lexer.l"
+#line 52 "attribctx_lexer.l"
 { cllval.ckattr = CKA_LABEL; return CKATTR_STR; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 50 "attribctx_lexer.l"
+#line 53 "attribctx_lexer.l"
 { cllval.ckattr = CKA_CLASS; return CKATTR_CLASS; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 51 "attribctx_lexer.l"
+#line 54 "attribctx_lexer.l"
 { cllval.ckattr = CKA_TOKEN; return CKATTR_BOOL; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 52 "attribctx_lexer.l"
+#line 55 "attribctx_lexer.l"
 { cllval.ckattr = CKA_KEY_TYPE; return CKATTR_KEY; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 53 "attribctx_lexer.l"
+#line 56 "attribctx_lexer.l"
 { cllval.ckattr = CKA_SUBJECT; return CKATTR_STR; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 54 "attribctx_lexer.l"
+#line 57 "attribctx_lexer.l"
 { cllval.ckattr = CKA_ENCRYPT; return CKATTR_BOOL; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 55 "attribctx_lexer.l"
+#line 58 "attribctx_lexer.l"
 { cllval.ckattr = CKA_DECRYPT; return CKATTR_BOOL; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 56 "attribctx_lexer.l"
+#line 59 "attribctx_lexer.l"
 { cllval.ckattr = CKA_WRAP; return CKATTR_BOOL; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 57 "attribctx_lexer.l"
+#line 60 "attribctx_lexer.l"
 { cllval.ckattr = CKA_UNWRAP; return CKATTR_BOOL; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 58 "attribctx_lexer.l"
+#line 61 "attribctx_lexer.l"
 { cllval.ckattr = CKA_SIGN; return CKATTR_BOOL; }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 59 "attribctx_lexer.l"
+#line 62 "attribctx_lexer.l"
 { cllval.ckattr = CKA_SIGN_RECOVER; return CKATTR_BOOL; }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 60 "attribctx_lexer.l"
+#line 63 "attribctx_lexer.l"
 { cllval.ckattr = CKA_VERIFY; return CKATTR_BOOL; }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 61 "attribctx_lexer.l"
+#line 64 "attribctx_lexer.l"
 { cllval.ckattr = CKA_VERIFY_RECOVER; return CKATTR_BOOL; }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 62 "attribctx_lexer.l"
+#line 65 "attribctx_lexer.l"
 { cllval.ckattr = CKA_DERIVE; return CKATTR_BOOL; }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 63 "attribctx_lexer.l"
+#line 66 "attribctx_lexer.l"
 { cllval.ckattr = CKA_PRIVATE; return CKATTR_BOOL; }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 64 "attribctx_lexer.l"
+#line 67 "attribctx_lexer.l"
 { cllval.ckattr = CKA_SENSITIVE; return CKATTR_BOOL; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 65 "attribctx_lexer.l"
+#line 68 "attribctx_lexer.l"
 { cllval.ckattr = CKA_EXTRACTABLE; return CKATTR_BOOL; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 66 "attribctx_lexer.l"
+#line 69 "attribctx_lexer.l"
 { cllval.ckattr = CKA_MODIFIABLE; return CKATTR_BOOL; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 67 "attribctx_lexer.l"
+#line 70 "attribctx_lexer.l"
 { cllval.ckattr = CKA_COPYABLE; return CKATTR_BOOL; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 68 "attribctx_lexer.l"
+#line 71 "attribctx_lexer.l"
 { cllval.ckattr = CKA_START_DATE; return CKATTR_DATE; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 69 "attribctx_lexer.l"
+#line 72 "attribctx_lexer.l"
 { cllval.ckattr = CKA_END_DATE; return CKATTR_DATE; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 70 "attribctx_lexer.l"
+#line 73 "attribctx_lexer.l"
 { cllval.ckattr = CKA_EC_PARAMS; return CKATTR_STR; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 71 "attribctx_lexer.l"
+#line 74 "attribctx_lexer.l"
 { cllval.ckattr = CKA_WRAP_TEMPLATE; return CKATTR_TEMPLATE; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 72 "attribctx_lexer.l"
+#line 75 "attribctx_lexer.l"
 { cllval.ckattr = CKA_UNWRAP_TEMPLATE; return CKATTR_TEMPLATE; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 73 "attribctx_lexer.l"
+#line 76 "attribctx_lexer.l"
 { cllval.ckattr = CKA_DERIVE_TEMPLATE; return CKATTR_TEMPLATE; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 74 "attribctx_lexer.l"
+#line 77 "attribctx_lexer.l"
 { cllval.ckattr = CKA_WRAP_WITH_TRUSTED; return CKATTR_BOOL; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 75 "attribctx_lexer.l"
+#line 78 "attribctx_lexer.l"
 { cllval.ckattr = CKA_TRUSTED; return CKATTR_BOOL; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 76 "attribctx_lexer.l"
+#line 79 "attribctx_lexer.l"
 { cllval.ckattr = CKA_ALLOWED_MECHANISMS; return CKATTR_ALLOWEDMECH; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 79 "attribctx_lexer.l"
+#line 82 "attribctx_lexer.l"
 { cllval.val_key = CKK_GENERIC_SECRET; return KEYTYPE; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 80 "attribctx_lexer.l"
+#line 83 "attribctx_lexer.l"
 { cllval.val_key = CKK_DES           ; return KEYTYPE; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 81 "attribctx_lexer.l"
+#line 84 "attribctx_lexer.l"
 { cllval.val_key = CKK_DES2          ; return KEYTYPE; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 82 "attribctx_lexer.l"
+#line 85 "attribctx_lexer.l"
 { cllval.val_key = CKK_DES3          ; return KEYTYPE; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 83 "attribctx_lexer.l"
+#line 86 "attribctx_lexer.l"
 { cllval.val_key = CKK_AES           ; return KEYTYPE; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 84 "attribctx_lexer.l"
+#line 87 "attribctx_lexer.l"
 { cllval.val_key = CKK_MD5_HMAC      ; return KEYTYPE; }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 85 "attribctx_lexer.l"
+#line 88 "attribctx_lexer.l"
 { cllval.val_key = CKK_SHA_1_HMAC    ; return KEYTYPE; }
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 86 "attribctx_lexer.l"
+#line 89 "attribctx_lexer.l"
 { cllval.val_key = CKK_RIPEMD128_HMAC; return KEYTYPE; }
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 87 "attribctx_lexer.l"
+#line 90 "attribctx_lexer.l"
 { cllval.val_key = CKK_RIPEMD160_HMAC; return KEYTYPE; }
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 88 "attribctx_lexer.l"
+#line 91 "attribctx_lexer.l"
 { cllval.val_key = CKK_SHA256_HMAC   ; return KEYTYPE; }
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 89 "attribctx_lexer.l"
+#line 92 "attribctx_lexer.l"
 { cllval.val_key = CKK_SHA384_HMAC   ; return KEYTYPE; }
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 90 "attribctx_lexer.l"
+#line 93 "attribctx_lexer.l"
 { cllval.val_key = CKK_SHA512_HMAC   ; return KEYTYPE; }
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 91 "attribctx_lexer.l"
+#line 94 "attribctx_lexer.l"
 { cllval.val_key = CKK_SHA224_HMAC   ; return KEYTYPE; }
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 92 "attribctx_lexer.l"
+#line 95 "attribctx_lexer.l"
 { cllval.val_key = CKK_RSA           ; return KEYTYPE; }
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 93 "attribctx_lexer.l"
+#line 96 "attribctx_lexer.l"
 { cllval.val_key = CKK_DH            ; return KEYTYPE; }
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 94 "attribctx_lexer.l"
+#line 97 "attribctx_lexer.l"
 { cllval.val_key = CKK_DSA           ; return KEYTYPE; }
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 95 "attribctx_lexer.l"
+#line 98 "attribctx_lexer.l"
 { cllval.val_key = CKK_EC            ; return KEYTYPE; }
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 96 "attribctx_lexer.l"
+#line 99 "attribctx_lexer.l"
 { cllval.val_key = CKK_EC_EDWARDS    ; return KEYTYPE; }
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 98 "attribctx_lexer.l"
+#line 101 "attribctx_lexer.l"
 { cllval.val_cls = CKO_DATA ; return OCLASS; }
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 99 "attribctx_lexer.l"
+#line 102 "attribctx_lexer.l"
 { cllval.val_cls = CKO_CERTIFICATE ; return OCLASS; }
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 100 "attribctx_lexer.l"
+#line 103 "attribctx_lexer.l"
 { cllval.val_cls = CKO_PUBLIC_KEY ; return OCLASS; }
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 101 "attribctx_lexer.l"
+#line 104 "attribctx_lexer.l"
 { cllval.val_cls = CKO_PRIVATE_KEY ; return OCLASS; }
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 102 "attribctx_lexer.l"
+#line 105 "attribctx_lexer.l"
 { cllval.val_cls = CKO_SECRET_KEY ; return OCLASS; }
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 103 "attribctx_lexer.l"
+#line 106 "attribctx_lexer.l"
 { cllval.val_cls = CKO_HW_FEATURE ; return OCLASS; }
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 104 "attribctx_lexer.l"
+#line 107 "attribctx_lexer.l"
 { cllval.val_cls = CKO_DOMAIN_PARAMETERS ; return OCLASS; }
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 105 "attribctx_lexer.l"
+#line 108 "attribctx_lexer.l"
 { cllval.val_cls = CKO_MECHANISM ; return OCLASS; }
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 106 "attribctx_lexer.l"
+#line 109 "attribctx_lexer.l"
 { cllval.val_cls = CKO_OTP_KEY ; return OCLASS; }
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 108 "attribctx_lexer.l"
+#line 111 "attribctx_lexer.l"
 { cllval.val_mech = pkcs11_get_mechanism_type_from_name(cltext);
                      if (cllval.val_mech==0xFFFFFFFF) {
 			clerror(NULL, "Unknown mechanism identifier <%s>", cltext);
@@ -1813,7 +2049,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 63:
 YY_RULE_SETUP
-#line 116 "attribctx_lexer.l"
+#line 119 "attribctx_lexer.l"
 {   if(strlen(cltext)%2==1) {
 			clerror(NULL, "Invalid hexadecimal string <%s>: odd length", cltext);
 			yyterminate();
@@ -1844,52 +2080,52 @@ YY_RULE_SETUP
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 144 "attribctx_lexer.l"
+#line 147 "attribctx_lexer.l"
 { memcpy(cllval.val_date.as_buffer, cltext, 8); return TOK_DATE; }
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 146 "attribctx_lexer.l"
+#line 149 "attribctx_lexer.l"
 { cllval.val_bool = 1; return TOK_BOOLEAN; }
 	YY_BREAK
 case 66:
 YY_RULE_SETUP
-#line 147 "attribctx_lexer.l"
+#line 150 "attribctx_lexer.l"
 { cllval.val_bool = 0; return TOK_BOOLEAN; }
 	YY_BREAK
 case 67:
 /* rule 67 can match eol */
 YY_RULE_SETUP
-#line 149 "attribctx_lexer.l"
+#line 152 "attribctx_lexer.l"
 { /* ignore whitespace and comma */ }
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 150 "attribctx_lexer.l"
+#line 153 "attribctx_lexer.l"
 { return ASSIGN; }
 	YY_BREAK
 case 69:
 YY_RULE_SETUP
-#line 151 "attribctx_lexer.l"
+#line 154 "attribctx_lexer.l"
 { return CURLY_OPEN; }
 	YY_BREAK
 case 70:
 YY_RULE_SETUP
-#line 152 "attribctx_lexer.l"
+#line 155 "attribctx_lexer.l"
 { return CURLY_CLOSE; }
 	YY_BREAK
 case 71:
 YY_RULE_SETUP
-#line 153 "attribctx_lexer.l"
+#line 156 "attribctx_lexer.l"
 { return cltext[0]; } /* catch-all http://stackoverflow.com/questions/18837828/how-should-i-handle-lexical-errors-in-my-flex-lexer */
 	YY_BREAK
 /* gives it back to bison, so error comes from parser */
 case 72:
 YY_RULE_SETUP
-#line 156 "attribctx_lexer.l"
+#line 159 "attribctx_lexer.l"
 ECHO;
 	YY_BREAK
-#line 1893 "attribctx_lexer.c"
+#line 2128 "attribctx_lexer.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1906,15 +2142,15 @@ case YY_STATE_EOF(INITIAL):
 			{
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
-			 * just pointed clin at a new source and called
-			 * cllex().  If so, then we have to assure
+			 * just pointed yyin at a new source and called
+			 * yylex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
 			 * back-up) that will match for the new input source.
 			 */
 			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
-			YY_CURRENT_BUFFER_LVALUE->yy_input_file = clin;
+			YY_CURRENT_BUFFER_LVALUE->yy_input_file = yyin;
 			YY_CURRENT_BUFFER_LVALUE->yy_buffer_status = YY_BUFFER_NORMAL;
 			}
 
@@ -1968,11 +2204,11 @@ case YY_STATE_EOF(INITIAL):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( clwrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
-					 * cltext, we can now set up
+					 * yytext, we can now set up
 					 * yy_c_buf_p so that if some total
 					 * hoser (like flex itself) wants to
 					 * call the scanner after we return the
@@ -2021,7 +2257,8 @@ case YY_STATE_EOF(INITIAL):
 			"fatal flex scanner internal error--no action found" );
 	} /* end of action switch */
 		} /* end of scanning one token */
-} /* end of cllex */
+	} /* end of user's declarations */
+} /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -2063,7 +2300,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -2076,7 +2313,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2090,7 +2327,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2099,11 +2336,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					clrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -2131,7 +2369,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			clrestart(clin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -2145,12 +2383,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) clrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -2184,9 +2425,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 869 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -2212,28 +2453,29 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 869 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 868);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
 
 #ifndef YY_NO_UNPUT
+
     static void yyunput (int c, char * yy_bp )
 {
 	char *yy_cp;
     
     yy_cp = (yy_c_buf_p);
 
-	/* undo effects of setting up cltext */
+	/* undo effects of setting up yytext */
 	*yy_cp = (yy_hold_char);
 
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		yy_size_t number_to_move = (yy_n_chars) + 2;
+		int number_to_move = (yy_n_chars) + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -2245,7 +2487,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -2254,14 +2496,15 @@ static int yy_get_next_buffer (void)
 	*--yy_cp = (char) c;
 
     if ( c == '\n' ){
-        --cllineno;
+        --yylineno;
     }
 
 	(yytext_ptr) = yy_bp;
 	(yy_hold_char) = *yy_cp;
 	(yy_c_buf_p) = yy_cp;
 }
-#endif	/* ifndef YY_NO_UNPUT */
+
+#endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
@@ -2287,7 +2530,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -2304,14 +2547,18 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					clrestart(clin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( clwrap( ) )
+					if ( yywrap(  ) )
+#ifdef YY_FLEX_LEX_COMPAT
+						return 0;
+#else
 						return EOF;
+#endif
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -2330,13 +2577,13 @@ static int yy_get_next_buffer (void)
 		}
 
 	c = *(unsigned char *) (yy_c_buf_p);	/* cast for 8-bit char's */
-	*(yy_c_buf_p) = '\0';	/* preserve cltext */
+	*(yy_c_buf_p) = '\0';	/* preserve yytext */
 	(yy_hold_char) = *++(yy_c_buf_p);
 
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = (c == '\n');
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_at_bol )
-		   
-    cllineno++;
+		
+    yylineno++;
 ;
 
 	return c;
@@ -2348,32 +2595,32 @@ static int yy_get_next_buffer (void)
  * 
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void clrestart  (FILE * input_file )
+    void yyrestart  (FILE * input_file )
 {
     
 	if ( ! YY_CURRENT_BUFFER ){
-        clensure_buffer_stack ();
+        yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            cl_create_buffer(clin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	cl_init_buffer(YY_CURRENT_BUFFER,input_file );
-	cl_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
  * 
  */
-    void cl_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
     
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		clpop_buffer_state();
-	 *		clpush_buffer_state(new_buffer);
+	 *		yypop_buffer_state();
+	 *		yypush_buffer_state(new_buffer);
      */
-	clensure_buffer_stack ();
+	yyensure_buffer_stack ();
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
@@ -2386,21 +2633,21 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	cl_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (clwrap()) processing, but the only time this flag
-	 * is looked at is after clwrap() is called, so it's safe
+	 * EOF (yywrap()) processing, but the only time this flag
+	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
-static void cl_load_buffer_state  (void)
+static void yy_load_buffer_state  (void)
 {
     	(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
 	(yytext_ptr) = (yy_c_buf_p) = YY_CURRENT_BUFFER_LVALUE->yy_buf_pos;
-	clin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
+	yyin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
 	(yy_hold_char) = *(yy_c_buf_p);
 }
 
@@ -2410,35 +2657,35 @@ static void cl_load_buffer_state  (void)
  * 
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE cl_create_buffer  (FILE * file, int  size )
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) clalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in cl_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) clalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in cl_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	cl_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with cl_create_buffer()
+ * @param b a buffer created with yy_create_buffer()
  * 
  */
-    void cl_delete_buffer (YY_BUFFER_STATE  b )
+    void yy_delete_buffer (YY_BUFFER_STATE  b )
 {
     
 	if ( ! b )
@@ -2448,27 +2695,27 @@ static void cl_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		clfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	clfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a clrestart() or at EOF.
+ * such as during a yyrestart() or at EOF.
  */
-    static void cl_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
 
 {
 	int oerrno = errno;
     
-	cl_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then cl_init_buffer was _probably_
-     * called from clrestart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then yy_init_buffer was _probably_
+     * called from yyrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -2485,7 +2732,7 @@ static void cl_load_buffer_state  (void)
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
  * 
  */
-    void cl_flush_buffer (YY_BUFFER_STATE  b )
+    void yy_flush_buffer (YY_BUFFER_STATE  b )
 {
     	if ( ! b )
 		return;
@@ -2505,7 +2752,7 @@ static void cl_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		cl_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -2514,14 +2761,14 @@ static void cl_load_buffer_state  (void)
  *  @param new_buffer The new state.
  *  
  */
-void clpush_buffer_state (YY_BUFFER_STATE new_buffer )
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
     	if (new_buffer == NULL)
 		return;
 
-	clensure_buffer_stack();
+	yyensure_buffer_stack();
 
-	/* This block is copied from cl_switch_to_buffer. */
+	/* This block is copied from yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
@@ -2535,8 +2782,8 @@ void clpush_buffer_state (YY_BUFFER_STATE new_buffer )
 		(yy_buffer_stack_top)++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from cl_switch_to_buffer. */
-	cl_load_buffer_state( );
+	/* copied from yy_switch_to_buffer. */
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -2544,18 +2791,18 @@ void clpush_buffer_state (YY_BUFFER_STATE new_buffer )
  *  The next element becomes the new top.
  *  
  */
-void clpop_buffer_state (void)
+void yypop_buffer_state (void)
 {
     	if (!YY_CURRENT_BUFFER)
 		return;
 
-	cl_delete_buffer(YY_CURRENT_BUFFER );
+	yy_delete_buffer(YY_CURRENT_BUFFER );
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if ((yy_buffer_stack_top) > 0)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		cl_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -2563,7 +2810,7 @@ void clpop_buffer_state (void)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void clensure_buffer_stack (void)
+static void yyensure_buffer_stack (void)
 {
 	yy_size_t num_to_alloc;
     
@@ -2573,15 +2820,15 @@ static void clensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1;
-		(yy_buffer_stack) = (struct yy_buffer_state**)clalloc
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in clensure_buffer_stack()" );
-								  
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -2590,15 +2837,15 @@ static void clensure_buffer_stack (void)
 	if ((yy_buffer_stack_top) >= ((yy_buffer_stack_max)) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
-		int grow_size = 8 /* arbitrary grow size */;
+		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
-		(yy_buffer_stack) = (struct yy_buffer_state**)clrealloc
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
 								((yy_buffer_stack),
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in clensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset((yy_buffer_stack) + (yy_buffer_stack_max), 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -2610,9 +2857,9 @@ static void clensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE cl_scan_buffer  (char * base, yy_size_t  size )
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
     
@@ -2620,69 +2867,69 @@ YY_BUFFER_STATE cl_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) clalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in cl_scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	cl_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to cllex() will
+/** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
  * 
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       cl_scan_bytes() instead.
+ *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE cl_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return cl_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to cllex() will
+/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE cl_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) clalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in cl_scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = cl_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in cl_scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -2696,9 +2943,9 @@ YY_BUFFER_STATE cl_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-    	(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2708,14 +2955,14 @@ static void yy_fatal_error (yyconst char* msg )
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up cltext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		cltext[clleng] = (yy_hold_char); \
-		(yy_c_buf_p) = cltext + yyless_macro_arg; \
+		yytext[yyleng] = (yy_hold_char); \
+		(yy_c_buf_p) = yytext + yyless_macro_arg; \
 		(yy_hold_char) = *(yy_c_buf_p); \
 		*(yy_c_buf_p) = '\0'; \
-		clleng = yyless_macro_arg; \
+		yyleng = yyless_macro_arg; \
 		} \
 	while ( 0 )
 
@@ -2724,129 +2971,129 @@ static void yy_fatal_error (yyconst char* msg )
 /** Get the current line number.
  * 
  */
-int clget_lineno  (void)
+int yyget_lineno  (void)
 {
-        
-    return cllineno;
+    
+    return yylineno;
 }
 
 /** Get the input stream.
  * 
  */
-FILE *clget_in  (void)
+FILE *yyget_in  (void)
 {
-        return clin;
+        return yyin;
 }
 
 /** Get the output stream.
  * 
  */
-FILE *clget_out  (void)
+FILE *yyget_out  (void)
 {
-        return clout;
+        return yyout;
 }
 
 /** Get the length of the current token.
  * 
  */
-yy_size_t clget_leng  (void)
+int yyget_leng  (void)
 {
-        return clleng;
+        return yyleng;
 }
 
 /** Get the current token.
  * 
  */
 
-char *clget_text  (void)
+char *yyget_text  (void)
 {
-        return cltext;
+        return yytext;
 }
 
 /** Set the current line number.
- * @param line_number
+ * @param _line_number line number
  * 
  */
-void clset_lineno (int  line_number )
+void yyset_lineno (int  _line_number )
 {
     
-    cllineno = line_number;
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
- * @param in_str A readable stream.
+ * @param _in_str A readable stream.
  * 
- * @see cl_switch_to_buffer
+ * @see yy_switch_to_buffer
  */
-void clset_in (FILE *  in_str )
+void yyset_in (FILE *  _in_str )
 {
-        clin = in_str ;
+        yyin = _in_str ;
 }
 
-void clset_out (FILE *  out_str )
+void yyset_out (FILE *  _out_str )
 {
-        clout = out_str ;
+        yyout = _out_str ;
 }
 
-int clget_debug  (void)
+int yyget_debug  (void)
 {
-        return cl_flex_debug;
+        return yy_flex_debug;
 }
 
-void clset_debug (int  bdebug )
+void yyset_debug (int  _bdebug )
 {
-        cl_flex_debug = bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
 {
         /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from cllex_destroy(), so don't allocate here.
+     * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    /* We do not touch cllineno unless the option is enabled. */
-    cllineno =  1;
+    /* We do not touch yylineno unless the option is enabled. */
+    yylineno =  1;
     
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
 /* Defined in main.c */
 #ifdef YY_STDINIT
-    clin = stdin;
-    clout = stdout;
+    yyin = stdin;
+    yyout = stdout;
 #else
-    clin = (FILE *) 0;
-    clout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * cllex_init()
+     * yylex_init()
      */
     return 0;
 }
 
-/* cllex_destroy is for both reentrant and non-reentrant scanners. */
-int cllex_destroy  (void)
+/* yylex_destroy is for both reentrant and non-reentrant scanners. */
+int yylex_destroy  (void)
 {
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		cl_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		clpop_buffer_state();
+		yypop_buffer_state();
 	}
 
 	/* Destroy the stack itself. */
-	clfree((yy_buffer_stack) );
+	yyfree((yy_buffer_stack) );
 	(yy_buffer_stack) = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * cllex() is called, initialization will occur. */
+     * yylex() is called, initialization will occur. */
     yy_init_globals( );
 
     return 0;
@@ -2857,8 +3104,9 @@ int cllex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
+		
 	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
@@ -2866,7 +3114,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -2876,13 +3124,14 @@ static int yy_flex_strlen (yyconst char * s )
 }
 #endif
 
-void *clalloc (yy_size_t  size )
+void *yyalloc (yy_size_t  size )
 {
-	return (void *) malloc( size );
+			return malloc(size);
 }
 
-void *clrealloc  (void * ptr, yy_size_t  size )
+void *yyrealloc  (void * ptr, yy_size_t  size )
 {
+		
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -2890,18 +3139,17 @@ void *clrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
-void clfree (void * ptr )
+void yyfree (void * ptr )
 {
-	free( (char *) ptr );	/* see clrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-#line 156 "attribctx_lexer.l"
-
+#line 159 "attribctx_lexer.l"
 
 
 

--- a/lib/attribctx_lexer.h
+++ b/lib/attribctx_lexer.h
@@ -2,7 +2,8 @@
 #define clHEADER_H 1
 #define clIN_HEADER 1
 
-#line 6 "attribctx_lexer.h"
+#line 5 "attribctx_lexer.h"
+#include <config.h>
 
 #line 8 "attribctx_lexer.h"
 
@@ -12,23 +13,247 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 37
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
 
-/* First, we deal with  platform-specific or compiler-specific issues. */
-
-#if defined(__FreeBSD__)
-#ifndef __STDC_LIMIT_MACROS
-#define	__STDC_LIMIT_MACROS
-#endif
-#include <sys/cdefs.h>
-#include <stdint.h>
+#ifdef yy_create_buffer
+#define cl_create_buffer_ALREADY_DEFINED
 #else
-#define	__dead2
+#define yy_create_buffer cl_create_buffer
 #endif
+
+#ifdef yy_delete_buffer
+#define cl_delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer cl_delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define cl_scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer cl_scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define cl_scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string cl_scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define cl_scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes cl_scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define cl_init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer cl_init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define cl_flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer cl_flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define cl_load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state cl_load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define cl_switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer cl_switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define clpush_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state clpush_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define clpop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state clpop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define clensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack clensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define cllex_ALREADY_DEFINED
+#else
+#define yylex cllex
+#endif
+
+#ifdef yyrestart
+#define clrestart_ALREADY_DEFINED
+#else
+#define yyrestart clrestart
+#endif
+
+#ifdef yylex_init
+#define cllex_init_ALREADY_DEFINED
+#else
+#define yylex_init cllex_init
+#endif
+
+#ifdef yylex_init_extra
+#define cllex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra cllex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define cllex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy cllex_destroy
+#endif
+
+#ifdef yyget_debug
+#define clget_debug_ALREADY_DEFINED
+#else
+#define yyget_debug clget_debug
+#endif
+
+#ifdef yyset_debug
+#define clset_debug_ALREADY_DEFINED
+#else
+#define yyset_debug clset_debug
+#endif
+
+#ifdef yyget_extra
+#define clget_extra_ALREADY_DEFINED
+#else
+#define yyget_extra clget_extra
+#endif
+
+#ifdef yyset_extra
+#define clset_extra_ALREADY_DEFINED
+#else
+#define yyset_extra clset_extra
+#endif
+
+#ifdef yyget_in
+#define clget_in_ALREADY_DEFINED
+#else
+#define yyget_in clget_in
+#endif
+
+#ifdef yyset_in
+#define clset_in_ALREADY_DEFINED
+#else
+#define yyset_in clset_in
+#endif
+
+#ifdef yyget_out
+#define clget_out_ALREADY_DEFINED
+#else
+#define yyget_out clget_out
+#endif
+
+#ifdef yyset_out
+#define clset_out_ALREADY_DEFINED
+#else
+#define yyset_out clset_out
+#endif
+
+#ifdef yyget_leng
+#define clget_leng_ALREADY_DEFINED
+#else
+#define yyget_leng clget_leng
+#endif
+
+#ifdef yyget_text
+#define clget_text_ALREADY_DEFINED
+#else
+#define yyget_text clget_text
+#endif
+
+#ifdef yyget_lineno
+#define clget_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno clget_lineno
+#endif
+
+#ifdef yyset_lineno
+#define clset_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno clset_lineno
+#endif
+
+#ifdef yywrap
+#define clwrap_ALREADY_DEFINED
+#else
+#define yywrap clwrap
+#endif
+
+#ifdef yyalloc
+#define clalloc_ALREADY_DEFINED
+#else
+#define yyalloc clalloc
+#endif
+
+#ifdef yyrealloc
+#define clrealloc_ALREADY_DEFINED
+#else
+#define yyrealloc clrealloc
+#endif
+
+#ifdef yyfree
+#define clfree_ALREADY_DEFINED
+#else
+#define yyfree clfree
+#endif
+
+#ifdef yytext
+#define cltext_ALREADY_DEFINED
+#else
+#define yytext cltext
+#endif
+
+#ifdef yyleng
+#define clleng_ALREADY_DEFINED
+#else
+#define yyleng clleng
+#endif
+
+#ifdef yyin
+#define clin_ALREADY_DEFINED
+#else
+#define yyin clin
+#endif
+
+#ifdef yyout
+#define clout_ALREADY_DEFINED
+#else
+#define yyout clout
+#endif
+
+#ifdef yy_flex_debug
+#define cl_flex_debug_ALREADY_DEFINED
+#else
+#define yy_flex_debug cl_flex_debug
+#endif
+
+#ifdef yylineno
+#define cllineno_ALREADY_DEFINED
+#else
+#define yylineno cllineno
+#endif
+
+/* First, we deal with  platform-specific or compiler-specific issues. */
 
 /* begin standard C headers. */
 #include <stdio.h>
@@ -99,34 +324,36 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 #ifndef YY_TYPEDEF_YY_BUFFER_STATE
@@ -139,9 +366,9 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t clleng;
+extern int yyleng;
 
-extern FILE *clin, *clout;
+extern FILE *yyin, *yyout;
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
@@ -155,12 +382,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -183,7 +410,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -194,31 +421,34 @@ struct yy_buffer_state
 	};
 #endif /* !YY_STRUCT_YY_BUFFER_STATE */
 
-void clrestart (FILE *input_file  );
-void cl_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE cl_create_buffer (FILE *file,int size  );
-void cl_delete_buffer (YY_BUFFER_STATE b  );
-void cl_flush_buffer (YY_BUFFER_STATE b  );
-void clpush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void clpop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-YY_BUFFER_STATE cl_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE cl_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE cl_scan_bytes (yyconst char *bytes,yy_size_t len  );
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-void *clalloc (yy_size_t  );
-void *clrealloc (void *,yy_size_t  );
-void clfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 /* Begin user sect3 */
 
-#define clwrap() 1
+#define clwrap() (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
 
-extern int cllineno;
+extern int yylineno;
 
-extern char *cltext;
-#define yytext_ptr cltext
+extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
+#define yytext_ptr yytext
 
 #ifdef YY_HEADER_EXPORT_START_CONDITIONS
 #define INITIAL 0
@@ -241,31 +471,31 @@ extern char *cltext;
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int cllex_destroy (void );
+int yylex_destroy ( void );
 
-int clget_debug (void );
+int yyget_debug ( void );
 
-void clset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE clget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void clset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *clget_in (void );
+FILE *yyget_in ( void );
 
-void clset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *clget_out (void );
+FILE *yyget_out ( void );
 
-void clset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t clget_leng (void );
+			int yyget_leng ( void );
 
-char *clget_text (void );
+char *yyget_text ( void );
 
-int clget_lineno (void );
+int yyget_lineno ( void );
 
-void clset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -273,18 +503,18 @@ void clset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int clwrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int clwrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
@@ -293,7 +523,12 @@ static int yy_flex_strlen (yyconst char * );
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Number of entries by which start-condition stack grows. */
@@ -307,9 +542,9 @@ static int yy_flex_strlen (yyconst char * );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int cllex (void);
+extern int yylex (void);
 
-#define YY_DECL int cllex (void)
+#define YY_DECL int yylex (void)
 #endif /* !YY_DECL */
 
 /* yy_get_previous_state - get the state just before the EOB char was reached */
@@ -326,9 +561,154 @@ extern int cllex (void);
 #undef YY_DECL
 #endif
 
-#line 156 "attribctx_lexer.l"
+#ifndef cl_create_buffer_ALREADY_DEFINED
+#undef yy_create_buffer
+#endif
+#ifndef cl_delete_buffer_ALREADY_DEFINED
+#undef yy_delete_buffer
+#endif
+#ifndef cl_scan_buffer_ALREADY_DEFINED
+#undef yy_scan_buffer
+#endif
+#ifndef cl_scan_string_ALREADY_DEFINED
+#undef yy_scan_string
+#endif
+#ifndef cl_scan_bytes_ALREADY_DEFINED
+#undef yy_scan_bytes
+#endif
+#ifndef cl_init_buffer_ALREADY_DEFINED
+#undef yy_init_buffer
+#endif
+#ifndef cl_flush_buffer_ALREADY_DEFINED
+#undef yy_flush_buffer
+#endif
+#ifndef cl_load_buffer_state_ALREADY_DEFINED
+#undef yy_load_buffer_state
+#endif
+#ifndef cl_switch_to_buffer_ALREADY_DEFINED
+#undef yy_switch_to_buffer
+#endif
+#ifndef clpush_buffer_state_ALREADY_DEFINED
+#undef yypush_buffer_state
+#endif
+#ifndef clpop_buffer_state_ALREADY_DEFINED
+#undef yypop_buffer_state
+#endif
+#ifndef clensure_buffer_stack_ALREADY_DEFINED
+#undef yyensure_buffer_stack
+#endif
+#ifndef cllex_ALREADY_DEFINED
+#undef yylex
+#endif
+#ifndef clrestart_ALREADY_DEFINED
+#undef yyrestart
+#endif
+#ifndef cllex_init_ALREADY_DEFINED
+#undef yylex_init
+#endif
+#ifndef cllex_init_extra_ALREADY_DEFINED
+#undef yylex_init_extra
+#endif
+#ifndef cllex_destroy_ALREADY_DEFINED
+#undef yylex_destroy
+#endif
+#ifndef clget_debug_ALREADY_DEFINED
+#undef yyget_debug
+#endif
+#ifndef clset_debug_ALREADY_DEFINED
+#undef yyset_debug
+#endif
+#ifndef clget_extra_ALREADY_DEFINED
+#undef yyget_extra
+#endif
+#ifndef clset_extra_ALREADY_DEFINED
+#undef yyset_extra
+#endif
+#ifndef clget_in_ALREADY_DEFINED
+#undef yyget_in
+#endif
+#ifndef clset_in_ALREADY_DEFINED
+#undef yyset_in
+#endif
+#ifndef clget_out_ALREADY_DEFINED
+#undef yyget_out
+#endif
+#ifndef clset_out_ALREADY_DEFINED
+#undef yyset_out
+#endif
+#ifndef clget_leng_ALREADY_DEFINED
+#undef yyget_leng
+#endif
+#ifndef clget_text_ALREADY_DEFINED
+#undef yyget_text
+#endif
+#ifndef clget_lineno_ALREADY_DEFINED
+#undef yyget_lineno
+#endif
+#ifndef clset_lineno_ALREADY_DEFINED
+#undef yyset_lineno
+#endif
+#ifndef clget_column_ALREADY_DEFINED
+#undef yyget_column
+#endif
+#ifndef clset_column_ALREADY_DEFINED
+#undef yyset_column
+#endif
+#ifndef clwrap_ALREADY_DEFINED
+#undef yywrap
+#endif
+#ifndef clget_lval_ALREADY_DEFINED
+#undef yyget_lval
+#endif
+#ifndef clset_lval_ALREADY_DEFINED
+#undef yyset_lval
+#endif
+#ifndef clget_lloc_ALREADY_DEFINED
+#undef yyget_lloc
+#endif
+#ifndef clset_lloc_ALREADY_DEFINED
+#undef yyset_lloc
+#endif
+#ifndef clalloc_ALREADY_DEFINED
+#undef yyalloc
+#endif
+#ifndef clrealloc_ALREADY_DEFINED
+#undef yyrealloc
+#endif
+#ifndef clfree_ALREADY_DEFINED
+#undef yyfree
+#endif
+#ifndef cltext_ALREADY_DEFINED
+#undef yytext
+#endif
+#ifndef clleng_ALREADY_DEFINED
+#undef yyleng
+#endif
+#ifndef clin_ALREADY_DEFINED
+#undef yyin
+#endif
+#ifndef clout_ALREADY_DEFINED
+#undef yyout
+#endif
+#ifndef cl_flex_debug_ALREADY_DEFINED
+#undef yy_flex_debug
+#endif
+#ifndef cllineno_ALREADY_DEFINED
+#undef yylineno
+#endif
+#ifndef cltables_fload_ALREADY_DEFINED
+#undef yytables_fload
+#endif
+#ifndef cltables_destroy_ALREADY_DEFINED
+#undef yytables_destroy
+#endif
+#ifndef clTABLES_NAME_ALREADY_DEFINED
+#undef yyTABLES_NAME
+#endif
+
+#line 159 "attribctx_lexer.l"
 
 
-#line 333 "attribctx_lexer.h"
+#line 712 "attribctx_lexer.h"
 #undef clIN_HEADER
 #endif /* clHEADER_H */

--- a/lib/attribctx_lexer.l
+++ b/lib/attribctx_lexer.l
@@ -23,8 +23,11 @@
 %option prefix="cl"
 %option outfile="lex.yy.c"
 
+%top{
+#include <config.h>
+}
+
 %{
-#include "config.h"
 #include <stdarg.h>
 #include "pkcs11lib.h"
 #include "attribctx_parser.h"

--- a/lib/attribctx_parser.c
+++ b/lib/attribctx_parser.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.7.6.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -46,10 +46,10 @@
    USER NAME SPACE" below.  */
 
 /* Identify Bison output, and Bison version.  */
-#define YYBISON 30706
+#define YYBISON 30802
 
 /* Bison version string.  */
-#define YYBISON_VERSION "3.7.6"
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -66,11 +66,12 @@
 /* "%code top" blocks.  */
 #line 23 "attribctx_parser.y"
 
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#line 74 "attribctx_parser.c"
+#line 75 "attribctx_parser.c"
 /* Substitute the type names.  */
 #define YYSTYPE         CLSTYPE
 /* Substitute the variable and function names.  */
@@ -124,12 +125,12 @@
 extern int cldebug;
 #endif
 /* "%code requires" blocks.  */
-#line 30 "attribctx_parser.y"
+#line 31 "attribctx_parser.y"
 
 #include "pkcs11lib.h"
 #include "attribctx_helper.h"
 
-#line 133 "attribctx_parser.c"
+#line 134 "attribctx_parser.c"
 
 /* Token kinds.  */
 #ifndef CLTOKENTYPE
@@ -165,7 +166,7 @@ extern int cldebug;
 #if ! defined CLSTYPE && ! defined CLSTYPE_IS_DECLARED
 union CLSTYPE
 {
-#line 46 "attribctx_parser.y"
+#line 47 "attribctx_parser.y"
 
     CK_ATTRIBUTE_TYPE ckattr;
     CK_KEY_TYPE val_key;
@@ -184,10 +185,10 @@ union CLSTYPE
 	    char month[2];
 	    char day[2];
 	} as_ck_date;
-        char as_buffer[8];
+	char as_buffer[8];
     } val_date;
 
-#line 191 "attribctx_parser.c"
+#line 192 "attribctx_parser.c"
 
 };
 typedef union CLSTYPE CLSTYPE;
@@ -198,17 +199,19 @@ typedef union CLSTYPE CLSTYPE;
 
 extern CLSTYPE cllval;
 
+
 int clparse (attribCtx *ctx);
+
 /* "%code provides" blocks.  */
-#line 35 "attribctx_parser.y"
+#line 36 "attribctx_parser.y"
 
 #define YY_DECL int yylex(attribCtx* ctx)
 
 YY_DECL;
 extern void clerror(attribCtx *ctx, const char *s, ...);
-    
 
-#line 212 "attribctx_parser.c"
+
+#line 215 "attribctx_parser.c"
 
 #endif /* !YY_CL_ATTRIBCTX_PARSER_H_INCLUDED  */
 /* Symbol kind.  */
@@ -401,12 +404,18 @@ typedef int yy_state_fast_t;
 # define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                            \
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
     _Pragma ("GCC diagnostic push")                                     \
     _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
 # define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
@@ -622,12 +631,12 @@ static const yytype_int8 yytranslate[] =
 };
 
 #if CLDEBUG
-  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    87,    87,    88,    91,    92,    93,    96,   103,   112,
-     121,   130,   137,   146,   153,   163,   162,   195,   210,   211,
-     214
+       0,    88,    88,    89,    92,    93,    94,    97,   104,   113,
+     122,   131,   138,   147,   154,   164,   163,   196,   211,   212,
+     215
 };
 #endif
 
@@ -658,16 +667,6 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_int16 yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274
-};
-#endif
-
 #define YYPACT_NINF (-15)
 
 #define yypact_value_is_default(Yyn) \
@@ -678,8 +677,8 @@ static const yytype_int16 yytoknum[] =
 #define yytable_value_is_error(Yyn) \
   0
 
-  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-     STATE-NUM.  */
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
       30,   -14,   -13,    -4,    -3,    -2,     8,     9,    12,     1,
@@ -688,9 +687,9 @@ static const yytype_int8 yypact[] =
      -15,    21,    30,   -15,    31,   -15,    14,   -15,   -15,   -15
 };
 
-  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
-     Performed when YYTABLE does not specify something else to do.  Zero
-     means the default is an error.  */
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
        0,     9,     0,     0,     0,     0,     0,     0,     0,     0,
@@ -699,21 +698,21 @@ static const yytype_int8 yydefact[] =
       15,     0,     0,    20,     0,    18,     0,    17,    19,    16
 };
 
-  /* YYPGOTO[NTERM-NUM].  */
+/* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
      -15,    15,    -9,   -15,   -15,   -15,   -15,   -15,    10
 };
 
-  /* YYDEFGOTO[NTERM-NUM].  */
+/* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
        0,     9,    10,    11,    12,    32,    13,    34,    35
 };
 
-  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
-     positive, shift that token.  If negative, reduce the rule whose
-     number is the opposite.  If YYTABLE_NINF, syntax error.  */
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int8 yytable[] =
 {
       23,    22,    26,    14,    15,     1,     2,     3,     4,     5,
@@ -734,8 +733,8 @@ static const yytype_int8 yycheck[] =
       19
 };
 
-  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-     symbol of state STATE-NUM.  */
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
 static const yytype_int8 yystos[] =
 {
        0,     4,     5,     6,     7,     8,     9,    10,    16,    21,
@@ -744,7 +743,7 @@ static const yytype_int8 yystos[] =
       18,    18,    25,    11,    27,    28,    21,    19,    28,    19
 };
 
-  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
        0,    20,    21,    21,    22,    22,    22,    23,    23,    23,
@@ -752,7 +751,7 @@ static const yytype_int8 yyr1[] =
       28
 };
 
-  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
        0,     2,     1,     2,     1,     1,     1,     3,     2,     1,
@@ -769,6 +768,7 @@ enum { YYENOMEM = -2 };
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
 #define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
 
 
 #define YYRECOVERING()  (!!yyerrstatus)
@@ -809,10 +809,7 @@ do {                                            \
     YYFPRINTF Args;                             \
 } while (0)
 
-/* This macro is provided for backward compatibility. */
-# ifndef YY_LOCATION_PRINT
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
+
 
 
 # define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
@@ -840,10 +837,6 @@ yy_symbol_value_print (FILE *yyo,
   YY_USE (ctx);
   if (!yyvaluep)
     return;
-# ifdef YYPRINT
-  if (yykind < YYNTOKENS)
-    YYPRINT (yyo, yytoknum[yykind], *yyvaluep);
-# endif
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   YY_USE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
@@ -1299,6 +1292,7 @@ yyparse (attribCtx *ctx)
   YYDPRINTF ((stderr, "Starting parse\n"));
 
   yychar = CLEMPTY; /* Cause a token to be read.  */
+
   goto yysetstate;
 
 
@@ -1324,7 +1318,7 @@ yysetstate:
 
   if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
-    goto yyexhaustedlab;
+    YYNOMEM;
 #else
     {
       /* Get the current used size of the three stacks, in elements.  */
@@ -1352,7 +1346,7 @@ yysetstate:
 # else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-        goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
         yystacksize = YYMAXDEPTH;
@@ -1363,7 +1357,7 @@ yysetstate:
           YY_CAST (union yyalloc *,
                    YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
-          goto yyexhaustedlab;
+          YYNOMEM;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
 #  undef YYSTACK_RELOCATE
@@ -1384,6 +1378,7 @@ yysetstate:
         YYABORT;
     }
 #endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
+
 
   if (yystate == YYFINAL)
     YYACCEPT;
@@ -1497,44 +1492,44 @@ yyreduce:
   switch (yyn)
     {
   case 7: /* simple_expr: CKATTR_BOOL ASSIGN TOK_BOOLEAN  */
-#line 97 "attribctx_parser.y"
+#line 98 "attribctx_parser.y"
                 {
 		    if(_attribctx_parser_append_attr(ctx, (yyvsp[-2].ckattr), &(yyvsp[0].val_bool), sizeof(CK_BBOOL) )!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign boolean value.");
 			YYERROR;
 		    }
 		}
-#line 1508 "attribctx_parser.c"
+#line 1503 "attribctx_parser.c"
     break;
 
   case 8: /* simple_expr: NO CKATTR_BOOL  */
-#line 104 "attribctx_parser.y"
+#line 105 "attribctx_parser.y"
                 {
 		    CK_BBOOL bfalse = CK_FALSE;
-		    
+
 		    if(_attribctx_parser_append_attr(ctx, (yyvsp[0].ckattr), &bfalse, sizeof(CK_BBOOL) )!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign boolean value.");
 			YYERROR;
 		    }
 		}
-#line 1521 "attribctx_parser.c"
+#line 1516 "attribctx_parser.c"
     break;
 
   case 9: /* simple_expr: CKATTR_BOOL  */
-#line 113 "attribctx_parser.y"
+#line 114 "attribctx_parser.y"
                 {
 		    CK_BBOOL btrue = CK_TRUE;
-		    
+
 		    if(_attribctx_parser_append_attr(ctx, (yyvsp[0].ckattr), &btrue, sizeof(CK_BBOOL) )!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign boolean value.");
 			YYERROR;
 		    }
 		}
-#line 1534 "attribctx_parser.c"
+#line 1529 "attribctx_parser.c"
     break;
 
   case 10: /* simple_expr: CKATTR_STR ASSIGN STRING  */
-#line 122 "attribctx_parser.y"
+#line 123 "attribctx_parser.y"
                 {
 		    if(_attribctx_parser_append_attr(ctx, (yyvsp[-2].ckattr), (yyvsp[0].val_str).val, (yyvsp[0].val_str).len)!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign bytes value.");
@@ -1543,22 +1538,22 @@ yyreduce:
 		    }
 		    free((yyvsp[0].val_str).val); /* we must free() as the buffer was copied */
 		}
-#line 1547 "attribctx_parser.c"
+#line 1542 "attribctx_parser.c"
     break;
 
   case 11: /* simple_expr: CKATTR_DATE ASSIGN TOK_DATE  */
-#line 131 "attribctx_parser.y"
+#line 132 "attribctx_parser.y"
                 {
 		    if(_attribctx_parser_append_attr(ctx, (yyvsp[-2].ckattr), (yyvsp[0].val_date).as_buffer, sizeof(CK_DATE))!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign date value.");
 			YYERROR;
 		    }
 		}
-#line 1558 "attribctx_parser.c"
+#line 1553 "attribctx_parser.c"
     break;
 
   case 12: /* simple_expr: CKATTR_DATE ASSIGN STRING  */
-#line 138 "attribctx_parser.y"
+#line 139 "attribctx_parser.y"
                 {
 		    if(_attribctx_parser_append_attr(ctx, (yyvsp[-2].ckattr), (yyvsp[0].val_str).val, (yyvsp[0].val_str).len)!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign date value.");
@@ -1567,58 +1562,58 @@ yyreduce:
 		    }
 		    free((yyvsp[0].val_str).val); /* we must free() as the buffer was copied */
 		}
-#line 1571 "attribctx_parser.c"
+#line 1566 "attribctx_parser.c"
     break;
 
   case 13: /* simple_expr: CKATTR_KEY ASSIGN KEYTYPE  */
-#line 147 "attribctx_parser.y"
+#line 148 "attribctx_parser.y"
                 {
 		    if(_attribctx_parser_append_attr(ctx, (yyvsp[-2].ckattr), &(yyvsp[0].val_key), sizeof(CK_KEY_TYPE))!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign key type value.");
 			YYERROR;
 		    }
 		}
-#line 1582 "attribctx_parser.c"
+#line 1577 "attribctx_parser.c"
     break;
 
   case 14: /* simple_expr: CKATTR_CLASS ASSIGN OCLASS  */
-#line 154 "attribctx_parser.y"
+#line 155 "attribctx_parser.y"
                 {
 		    if(_attribctx_parser_append_attr(ctx, (yyvsp[-2].ckattr), &(yyvsp[0].val_cls), sizeof(CK_OBJECT_CLASS))!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign object class value.");
 			YYERROR;
 		    }
 		}
-#line 1593 "attribctx_parser.c"
+#line 1588 "attribctx_parser.c"
     break;
 
   case 15: /* $@1: %empty  */
-#line 163 "attribctx_parser.y"
+#line 164 "attribctx_parser.y"
                 {
 		    if(ctx->level==1) {
 			clerror(ctx, "***Error: nesting templates not allowed");
 			YYERROR;
 		    }
-                    ctx->level++; /*remind we are in a curly brace */
-		    
+		    ctx->level++; /*remind we are in a curly brace */
+
 		    ctx->current_idx = ctx->saved_idx + 1; /*increment current idx from ctx->saved_idx */
 		    if(ctx->current_idx>=4) {
 			clerror(ctx, "***Error: too many templates specified");
 			YYERROR;
-                   } 		    
+		   }
 		}
-#line 1611 "attribctx_parser.c"
+#line 1606 "attribctx_parser.c"
     break;
 
   case 16: /* template_expr: CKATTR_TEMPLATE ASSIGN CURLY_OPEN $@1 statement CURLY_CLOSE  */
-#line 177 "attribctx_parser.y"
+#line 178 "attribctx_parser.y"
                 {
 
 		    if(ctx->level==0) {
-		        clerror(ctx, "***Error: no matching opening curly brace");
+			clerror(ctx, "***Error: no matching opening curly brace");
 			YYERROR;
-                    }
-                    ctx->level--; /*out of curly brace now */
+		    }
+		    ctx->level--; /*out of curly brace now */
 
 		    ctx->saved_idx = ctx->current_idx; /* remember which index we used last */
 		    ctx->current_idx = ctx->mainlist_idx; /* should be always 0 */
@@ -1626,13 +1621,13 @@ yyreduce:
 		    if(_attribctx_parser_assign_list_to_template(ctx, (yyvsp[-5].ckattr))!=rc_ok) {
 			clerror(ctx, "Error during parsing, cannot assign attribute list to a template attribute.");
 			YYERROR;
-		    }		    
+		    }
 		}
-#line 1632 "attribctx_parser.c"
+#line 1627 "attribctx_parser.c"
     break;
 
   case 17: /* allowedmech_expr: CKATTR_ALLOWEDMECH ASSIGN CURLY_OPEN mechanisms CURLY_CLOSE  */
-#line 196 "attribctx_parser.y"
+#line 197 "attribctx_parser.y"
                 {
 		    if( _attribctx_parser_append_attr( ctx,
 						       (yyvsp[-4].ckattr),
@@ -1645,22 +1640,22 @@ yyreduce:
 		    /* pointer stolen, we must free it */
 		    pkcs11_attribctx_forget_mechanisms(ctx);
 		}
-#line 1649 "attribctx_parser.c"
+#line 1644 "attribctx_parser.c"
     break;
 
   case 20: /* mechanism: CKMECH  */
-#line 215 "attribctx_parser.y"
+#line 216 "attribctx_parser.y"
                 {
 		    if( pkcs11_attribctx_add_mechanism(ctx, (yyvsp[0].val_mech))!=rc_ok) {
 			clerror(ctx, "Error during parsing, cannot assign mechanism to allowed mechanisms.");
 			YYERROR;
 		    }
 		}
-#line 1660 "attribctx_parser.c"
+#line 1655 "attribctx_parser.c"
     break;
 
 
-#line 1664 "attribctx_parser.c"
+#line 1659 "attribctx_parser.c"
 
       default: break;
     }
@@ -1736,7 +1731,7 @@ yyerrlab:
           }
         yyerror (ctx, yymsgp);
         if (yysyntax_error_status == YYENOMEM)
-          goto yyexhaustedlab;
+          YYNOMEM;
       }
     }
 
@@ -1772,6 +1767,7 @@ yyerrorlab:
      label yyerrorlab therefore never appears in user code.  */
   if (0)
     YYERROR;
+  ++yynerrs;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -1832,7 +1828,7 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
 
 
 /*-----------------------------------.
@@ -1840,24 +1836,22 @@ yyacceptlab:
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
 
-#if 1
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (ctx, YY_("memory exhausted"));
   yyresult = 2;
-  goto yyreturn;
-#endif
+  goto yyreturnlab;
 
 
-/*-------------------------------------------------------.
-| yyreturn -- parsing is finished, clean up and return.  |
-`-------------------------------------------------------*/
-yyreturn:
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
   if (yychar != CLEMPTY)
     {
       /* Make sure we have latest lookahead translation.  See comments at
@@ -1885,5 +1879,5 @@ yyreturn:
   return yyresult;
 }
 
-#line 222 "attribctx_parser.y"
-	      
+#line 223 "attribctx_parser.y"
+

--- a/lib/attribctx_parser.h
+++ b/lib/attribctx_parser.h
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.7.6.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
@@ -53,7 +53,7 @@
 extern int cldebug;
 #endif
 /* "%code requires" blocks.  */
-#line 30 "attribctx_parser.y"
+#line 31 "attribctx_parser.y"
 
 #include "pkcs11lib.h"
 #include "attribctx_helper.h"
@@ -94,7 +94,7 @@ extern int cldebug;
 #if ! defined CLSTYPE && ! defined CLSTYPE_IS_DECLARED
 union CLSTYPE
 {
-#line 46 "attribctx_parser.y"
+#line 47 "attribctx_parser.y"
 
     CK_ATTRIBUTE_TYPE ckattr;
     CK_KEY_TYPE val_key;
@@ -113,7 +113,7 @@ union CLSTYPE
 	    char month[2];
 	    char day[2];
 	} as_ck_date;
-        char as_buffer[8];
+	char as_buffer[8];
     } val_date;
 
 #line 120 "attribctx_parser.h"
@@ -127,16 +127,18 @@ typedef union CLSTYPE CLSTYPE;
 
 extern CLSTYPE cllval;
 
+
 int clparse (attribCtx *ctx);
+
 /* "%code provides" blocks.  */
-#line 35 "attribctx_parser.y"
+#line 36 "attribctx_parser.y"
 
 #define YY_DECL int yylex(attribCtx* ctx)
 
 YY_DECL;
 extern void clerror(attribCtx *ctx, const char *s, ...);
-    
 
-#line 141 "attribctx_parser.h"
+
+#line 143 "attribctx_parser.h"
 
 #endif /* !YY_CL_ATTRIBCTX_PARSER_H_INCLUDED  */

--- a/lib/attribctx_parser.y
+++ b/lib/attribctx_parser.y
@@ -21,12 +21,13 @@
 /* %define lr.type canonical-lr */
 
 %code top {
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 }
 
-			
+
 %code requires {
 #include "pkcs11lib.h"
 #include "attribctx_helper.h"
@@ -37,9 +38,9 @@
 
 YY_DECL;
 extern void clerror(attribCtx *ctx, const char *s, ...);
-    
+
 }
-			
+
 %param { attribCtx *ctx }
 
 
@@ -61,7 +62,7 @@ extern void clerror(attribCtx *ctx, const char *s, ...);
 	    char month[2];
 	    char day[2];
 	} as_ck_date;
-        char as_buffer[8];
+	char as_buffer[8];
     } val_date;
 }
 
@@ -69,13 +70,13 @@ extern void clerror(attribCtx *ctx, const char *s, ...);
 %token <val_str> STRING
 
 %token <ckattr> CKATTR_BOOL CKATTR_STR CKATTR_DATE CKATTR_KEY CKATTR_CLASS CKATTR_TEMPLATE CKATTR_ALLOWEDMECH
-%token <val_mech> CKMECH		
+%token <val_mech> CKMECH
 %token <val_bool> TOK_BOOLEAN
 %token <val_date> TOK_DATE
 %token <val_key>  KEYTYPE
 %token <val_cls>  OCLASS
 %nonassoc NO
-%token ASSIGN CURLY_OPEN CURLY_CLOSE			
+%token ASSIGN CURLY_OPEN CURLY_CLOSE
 
 %%
 
@@ -94,32 +95,32 @@ expression:	simple_expr
 	;
 
 simple_expr:	CKATTR_BOOL ASSIGN TOK_BOOLEAN
-                {
+		{
 		    if(_attribctx_parser_append_attr(ctx, $1, &$3, sizeof(CK_BBOOL) )!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign boolean value.");
 			YYERROR;
 		    }
 		}
 	|	NO CKATTR_BOOL
-                {
+		{
 		    CK_BBOOL bfalse = CK_FALSE;
-		    
+
 		    if(_attribctx_parser_append_attr(ctx, $2, &bfalse, sizeof(CK_BBOOL) )!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign boolean value.");
 			YYERROR;
 		    }
-		}		
+		}
 	|	CKATTR_BOOL
-                {
+		{
 		    CK_BBOOL btrue = CK_TRUE;
-		    
+
 		    if(_attribctx_parser_append_attr(ctx, $1, &btrue, sizeof(CK_BBOOL) )!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign boolean value.");
 			YYERROR;
 		    }
 		}
 	|	CKATTR_STR ASSIGN STRING
-                {
+		{
 		    if(_attribctx_parser_append_attr(ctx, $1, $3.val, $3.len)!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign bytes value.");
 			free($3.val); /* we must free() as the buffer was copied */
@@ -128,14 +129,14 @@ simple_expr:	CKATTR_BOOL ASSIGN TOK_BOOLEAN
 		    free($3.val); /* we must free() as the buffer was copied */
 		}
 	|	CKATTR_DATE ASSIGN TOK_DATE
-                {
+		{
 		    if(_attribctx_parser_append_attr(ctx, $1, $3.as_buffer, sizeof(CK_DATE))!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign date value.");
 			YYERROR;
 		    }
 		}
 	|	CKATTR_DATE  ASSIGN STRING /* if the date comes as 0x... format (not preferred but accepted) */
-                {
+		{
 		    if(_attribctx_parser_append_attr(ctx, $1, $3.val, $3.len)!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign date value.");
 			free($3.val); /* we must free() as the buffer was copied */
@@ -144,14 +145,14 @@ simple_expr:	CKATTR_BOOL ASSIGN TOK_BOOLEAN
 		    free($3.val); /* we must free() as the buffer was copied */
 		}
 	|	CKATTR_KEY ASSIGN KEYTYPE
-                {
+		{
 		    if(_attribctx_parser_append_attr(ctx, $1, &$3, sizeof(CK_KEY_TYPE))!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign key type value.");
 			YYERROR;
 		    }
 		}
 	|	CKATTR_CLASS ASSIGN OCLASS
-                {
+		{
 		    if(_attribctx_parser_append_attr(ctx, $1, &$3, sizeof(CK_OBJECT_CLASS))!=rc_ok) {
 			clerror(ctx,"Error during parsing, cannot assign object class value.");
 			YYERROR;
@@ -165,22 +166,22 @@ template_expr:	CKATTR_TEMPLATE ASSIGN CURLY_OPEN
 			clerror(ctx, "***Error: nesting templates not allowed");
 			YYERROR;
 		    }
-                    ctx->level++; /*remind we are in a curly brace */
-		    
+		    ctx->level++; /*remind we are in a curly brace */
+
 		    ctx->current_idx = ctx->saved_idx + 1; /*increment current idx from ctx->saved_idx */
 		    if(ctx->current_idx>=4) {
 			clerror(ctx, "***Error: too many templates specified");
 			YYERROR;
-                   } 		    
+		   }
 		}
 		statement CURLY_CLOSE
 		{
 
 		    if(ctx->level==0) {
-		        clerror(ctx, "***Error: no matching opening curly brace");
+			clerror(ctx, "***Error: no matching opening curly brace");
 			YYERROR;
-                    }
-                    ctx->level--; /*out of curly brace now */
+		    }
+		    ctx->level--; /*out of curly brace now */
 
 		    ctx->saved_idx = ctx->current_idx; /* remember which index we used last */
 		    ctx->current_idx = ctx->mainlist_idx; /* should be always 0 */
@@ -188,7 +189,7 @@ template_expr:	CKATTR_TEMPLATE ASSIGN CURLY_OPEN
 		    if(_attribctx_parser_assign_list_to_template(ctx, $1)!=rc_ok) {
 			clerror(ctx, "Error during parsing, cannot assign attribute list to a template attribute.");
 			YYERROR;
-		    }		    
+		    }
 		}
 	;
 
@@ -219,4 +220,4 @@ mechanism:	CKMECH
 		    }
 		}
 	;
-%%	      
+%%

--- a/lib/wrappedkey_lexer.c
+++ b/lib/wrappedkey_lexer.c
@@ -1,3 +1,4 @@
+#include <config.h>
 
 #line 3 "wrappedkey_lexer.c"
 
@@ -7,23 +8,13 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 37
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
-
-#if defined(__FreeBSD__)
-#ifndef __STDC_LIMIT_MACROS
-#define	__STDC_LIMIT_MACROS
-#endif
-#include <sys/cdefs.h>
-#include <stdint.h>
-#else
-#define	__dead2
-#endif
 
 /* begin standard C headers. */
 #include <stdio.h>
@@ -94,65 +85,61 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart(yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 /* The state buf must be large enough to hold one state per character in the main buffer.
@@ -169,17 +156,17 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     /* Note: We specifically omit the test for yy_rule_can_match_eol because it requires
      *       access to the local variable yy_act. Since yyless() is a macro, it would break
-     *       existing scanners that call yyless() from OUTSIDE yylex. 
+     *       existing scanners that call yyless() from OUTSIDE yylex.
      *       One obvious solution it to make yy_act a global. I tried that, and saw
      *       a 5% performance hit in a non-yylineno scanner, because yy_act is
      *       normally declared as a register variable-- so it is not worth it.
@@ -189,6 +176,13 @@ extern FILE *yyin, *yyout;
                 int yyl;\
                 for ( yyl = n; yyl < yyleng; ++yyl )\
                     if ( yytext[yyl] == '\n' )\
+                        --yylineno;\
+            }while(0)
+    #define YY_LINENO_REWIND_TO(dst) \
+            do {\
+                const char *p;\
+                for ( p = yy_cp-1; p >= (dst); --p)\
+                    if ( *p == '\n' )\
                         --yylineno;\
             }while(0)
     
@@ -205,7 +199,6 @@ extern FILE *yyin, *yyout;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -220,12 +213,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -248,7 +241,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -276,7 +269,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -288,7 +281,6 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
 #define yy_current_buffer YY_CURRENT_BUFFER
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
@@ -296,11 +288,11 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t yyleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
@@ -309,85 +301,81 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void yyensure_buffer_stack (void );
-static void yy_load_buffer_state (void );
-static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
-
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 #define yy_new_buffer yy_create_buffer
-
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
 
-#define yywrap() 1
+#define yywrap() (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *yyin = (FILE *) 0, *yyout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
 extern int yylineno;
-
 int yylineno = 1;
 
 extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
 #define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-static void yy_fatal_error (yyconst char msg[]  ) __dead2;
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 105
 #define YY_END_OF_BUFFER 106
 /* This struct is not used in this scanner,
@@ -397,7 +385,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[817] =
+static const flex_int16_t yy_accept[817] =
     {   0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
       106,  104,  103,  103,   10,   99,   98,  104,   94,  104,
@@ -491,7 +479,7 @@ static yyconst flex_int16_t yy_accept[817] =
         0,    0,    5,    0,    2,    0
     } ;
 
-static yyconst flex_int32_t yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    4,    1,    1,    1,    1,    1,    1,    1,
@@ -523,7 +511,7 @@ static yyconst flex_int32_t yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int32_t yy_meta[73] =
+static const YY_CHAR yy_meta[73] =
     {   0,
         1,    1,    2,    3,    1,    4,    1,    3,    1,    5,
         3,    6,    6,    6,    6,    6,    6,    6,    6,    6,
@@ -535,7 +523,7 @@ static yyconst flex_int32_t yy_meta[73] =
         9,    8
     } ;
 
-static yyconst flex_int16_t yy_base[832] =
+static const flex_int16_t yy_base[832] =
     {   0,
         0,   66,   73,   75,   77,   79,   82,   86, 1569, 1568,
      1573, 1576,   89,   94, 1576,   64,   77,    0, 1576,   66,
@@ -631,7 +619,7 @@ static yyconst flex_int16_t yy_base[832] =
      1496
     } ;
 
-static yyconst flex_int16_t yy_def[832] =
+static const flex_int16_t yy_def[832] =
     {   0,
       816,    1,  817,  817,  817,  817,  817,  817,  818,  818,
       816,  816,  816,  816,  816,  819,  819,   17,  816,  816,
@@ -727,7 +715,7 @@ static yyconst flex_int16_t yy_def[832] =
       816
     } ;
 
-static yyconst flex_int16_t yy_nxt[1649] =
+static const flex_int16_t yy_nxt[1649] =
     {   0,
        12,   13,   14,   13,   13,   15,   12,   12,   12,   12,
        12,   16,   17,   18,   18,   18,   18,   18,   18,   18,
@@ -912,7 +900,7 @@ static yyconst flex_int16_t yy_nxt[1649] =
       816,  816,  816,  816,  816,  816,  816,  816
     } ;
 
-static yyconst flex_int16_t yy_chk[1649] =
+static const flex_int16_t yy_chk[1649] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -1098,7 +1086,7 @@ static yyconst flex_int16_t yy_chk[1649] =
     } ;
 
 /* Table of booleans, true if rule could match eol. */
-static yyconst flex_int32_t yy_rule_can_match_eol[106] =
+static const flex_int32_t yy_rule_can_match_eol[106] =
     {   0,
 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
@@ -1139,16 +1127,17 @@ char *yytext;
  * limitations under the License.
  */
 /* %option debug */
-#line 25 "wrappedkey_lexer.l"
-#include "config.h"
+
+#line 29 "wrappedkey_lexer.l"
 #include <stdarg.h>
 #include "wrappedkey_parser.h"
 
 #define PUBLIC_KEY_PROLOG "-----BEGIN PUBLIC KEY-----"
 #define PUBLIC_KEY_EPILOG "-----END PUBLIC KEY-----"
 
+#line 1138 "wrappedkey_lexer.c"
 
-#line 1152 "wrappedkey_lexer.c"
+#line 1140 "wrappedkey_lexer.c"
 
 #define INITIAL 0
 #define OUTERKEYPEM 1
@@ -1168,36 +1157,36 @@ char *yytext;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -1205,37 +1194,43 @@ void yyset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
-    static void yyunput (int c,char *buf_ptr  );
-#endif
     
+    static void yyunput ( int c, char *buf_ptr  );
+    
+#endif
+
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Copy whatever the last rule matched to the standard output. */
@@ -1243,7 +1238,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -1254,7 +1249,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -1267,7 +1262,7 @@ static int input (void );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -1322,7 +1317,7 @@ extern int yylex (void);
 
 /* Code executed at the end of each rule. */
 #ifndef YY_BREAK
-#define YY_BREAK break;
+#define YY_BREAK /*LINTED*/break;
 #endif
 
 #define YY_RULE_SETUP \
@@ -1339,11 +1334,6 @@ YY_DECL
 	char *yy_cp, *yy_bp;
 	int yy_act;
     
-#line 35 "wrappedkey_lexer.l"
-
-
-#line 1346 "wrappedkey_lexer.c"
-
 	if ( !(yy_init) )
 		{
 		(yy_init) = 1;
@@ -1364,13 +1354,19 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer(yyin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
-	while ( 1 )		/* loops until end-of-file is reached */
+	{
+#line 38 "wrappedkey_lexer.l"
+
+
+#line 1367 "wrappedkey_lexer.c"
+
+	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
@@ -1397,9 +1393,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 817 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_current_state != 816 );
@@ -1413,10 +1409,10 @@ yy_find_action:
 
 		if ( yy_act != YY_END_OF_BUFFER && yy_rule_can_match_eol[yy_act] )
 			{
-			yy_size_t yyl;
+			int yyl;
 			for ( yyl = 0; yyl < yyleng; ++yyl )
 				if ( yytext[yyl] == '\n' )
-					   
+					
     yylineno++;
 ;
 			}
@@ -1434,75 +1430,75 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 37 "wrappedkey_lexer.l"
+#line 40 "wrappedkey_lexer.l"
 { /* skipping comment */ }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 39 "wrappedkey_lexer.l"
+#line 42 "wrappedkey_lexer.l"
 { BEGIN(OUTERKEYPEM); }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 40 "wrappedkey_lexer.l"
+#line 43 "wrappedkey_lexer.l"
 { BEGIN(INNERKEYPEM); }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 41 "wrappedkey_lexer.l"
+#line 44 "wrappedkey_lexer.l"
 { BEGIN(PUBKPEM); }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 43 "wrappedkey_lexer.l"
+#line 46 "wrappedkey_lexer.l"
 { BEGIN(INITIAL); return OUTER; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 44 "wrappedkey_lexer.l"
+#line 47 "wrappedkey_lexer.l"
 { BEGIN(INITIAL); return INNER; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 45 "wrappedkey_lexer.l"
+#line 48 "wrappedkey_lexer.l"
 { BEGIN(INITIAL); return PUBK; }
 	YY_BREAK
 case YY_STATE_EOF(OUTERKEYPEM):
 case YY_STATE_EOF(INNERKEYPEM):
 case YY_STATE_EOF(PUBKPEM):
-#line 47 "wrappedkey_lexer.l"
+#line 50 "wrappedkey_lexer.l"
 { yyerror(NULL, "Incomplete PEM block"); yyterminate(); }
 	YY_BREAK
 case 8:
 /* rule 8 can match eol */
 YY_RULE_SETUP
-#line 48 "wrappedkey_lexer.l"
+#line 51 "wrappedkey_lexer.l"
 { yylval.val_pem = (unsigned char *)strdup(yytext); }
 	YY_BREAK
 case 9:
 /* rule 9 can match eol */
 YY_RULE_SETUP
-#line 49 "wrappedkey_lexer.l"
+#line 52 "wrappedkey_lexer.l"
 { /* ignore initial line feed */ }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 51 "wrappedkey_lexer.l"
+#line 54 "wrappedkey_lexer.l"
 { yylval.val_str.len=0; BEGIN(STR); }
 	YY_BREAK
 case 11:
 /* rule 11 can match eol */
 YY_RULE_SETUP
-#line 52 "wrappedkey_lexer.l"
+#line 55 "wrappedkey_lexer.l"
 { yylval.val_str.val = strdup(yytext); yylval.val_str.len = strlen(yytext); }
 	YY_BREAK
 case YY_STATE_EOF(STR):
-#line 53 "wrappedkey_lexer.l"
+#line 56 "wrappedkey_lexer.l"
 { yyerror(NULL, "Unterminated quoted string"); yyterminate(); }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 54 "wrappedkey_lexer.l"
+#line 57 "wrappedkey_lexer.l"
 {   /* special case: if we have an empty string, regular rule is never executed */
 		/* in which case, we perform the empty string assignment from here */
                 if (yylval.val_str.len==0) { yylval.val_str.val=strdup(""); } BEGIN(INITIAL); return STRING;
@@ -1510,377 +1506,377 @@ YY_RULE_SETUP
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 59 "wrappedkey_lexer.l"
+#line 62 "wrappedkey_lexer.l"
 { return CTYPE; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 60 "wrappedkey_lexer.l"
+#line 63 "wrappedkey_lexer.l"
 { yylval.val_contenttype = ct_appl_p11; return CTYPE_VAL; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 62 "wrappedkey_lexer.l"
+#line 65 "wrappedkey_lexer.l"
 { return WRAPPING_ALG; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 63 "wrappedkey_lexer.l"
+#line 66 "wrappedkey_lexer.l"
 { yylval.val_wrappingmethod = w_pkcs1_15; return PKCS1ALGO; }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 64 "wrappedkey_lexer.l"
+#line 67 "wrappedkey_lexer.l"
 { yylval.val_wrappingmethod = w_pkcs1_oaep; return OAEPALGO;  }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 65 "wrappedkey_lexer.l"
+#line 68 "wrappedkey_lexer.l"
 { yylval.val_wrappingmethod = w_cbcpad; return CBCPADALGO;  }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 66 "wrappedkey_lexer.l"
+#line 69 "wrappedkey_lexer.l"
 { yylval.val_wrappingmethod = w_rfc3394; return RFC3394ALGO;  }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 67 "wrappedkey_lexer.l"
+#line 70 "wrappedkey_lexer.l"
 { yylval.val_wrappingmethod = w_rfc5649; return RFC5649ALGO;  }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 68 "wrappedkey_lexer.l"
+#line 71 "wrappedkey_lexer.l"
 { yylval.val_wrappingmethod = w_envelope; return ENVELOPEALGO; }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 70 "wrappedkey_lexer.l"
+#line 73 "wrappedkey_lexer.l"
 { return WRAPPING_KEY; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 71 "wrappedkey_lexer.l"
+#line 74 "wrappedkey_lexer.l"
 { return GRAMMAR_VERSION; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 73 "wrappedkey_lexer.l"
+#line 76 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_ID; return CKATTR_STR; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 74 "wrappedkey_lexer.l"
+#line 77 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_LABEL; return CKATTR_STR; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 75 "wrappedkey_lexer.l"
+#line 78 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_CLASS; return CKATTR_CLASS; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 76 "wrappedkey_lexer.l"
+#line 79 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_TOKEN; return CKATTR_BOOL; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 77 "wrappedkey_lexer.l"
+#line 80 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_KEY_TYPE; return CKATTR_KEY; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 78 "wrappedkey_lexer.l"
+#line 81 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_SUBJECT; return CKATTR_STR; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 79 "wrappedkey_lexer.l"
+#line 82 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_ENCRYPT; return CKATTR_BOOL; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 80 "wrappedkey_lexer.l"
+#line 83 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_DECRYPT; return CKATTR_BOOL; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 81 "wrappedkey_lexer.l"
+#line 84 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_WRAP; return CKATTR_BOOL; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 82 "wrappedkey_lexer.l"
+#line 85 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_UNWRAP; return CKATTR_BOOL; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 83 "wrappedkey_lexer.l"
+#line 86 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_SIGN; return CKATTR_BOOL; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 84 "wrappedkey_lexer.l"
+#line 87 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_SIGN_RECOVER; return CKATTR_BOOL; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 85 "wrappedkey_lexer.l"
+#line 88 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_VERIFY; return CKATTR_BOOL; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 86 "wrappedkey_lexer.l"
+#line 89 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_VERIFY_RECOVER; return CKATTR_BOOL; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 87 "wrappedkey_lexer.l"
+#line 90 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_DERIVE; return CKATTR_BOOL; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 88 "wrappedkey_lexer.l"
+#line 91 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_PRIVATE; return CKATTR_BOOL; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 89 "wrappedkey_lexer.l"
+#line 92 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_SENSITIVE; return CKATTR_BOOL; }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 90 "wrappedkey_lexer.l"
+#line 93 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_EXTRACTABLE; return CKATTR_BOOL; }
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 91 "wrappedkey_lexer.l"
+#line 94 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_MODIFIABLE; return CKATTR_BOOL; }
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 92 "wrappedkey_lexer.l"
+#line 95 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_START_DATE; return CKATTR_DATE; }
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 93 "wrappedkey_lexer.l"
+#line 96 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_END_DATE; return CKATTR_DATE; }
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 94 "wrappedkey_lexer.l"
+#line 97 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_CHECK_VALUE; return CKATTR_STR; }
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 95 "wrappedkey_lexer.l"
+#line 98 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_EC_PARAMS; return CKATTR_STR; }
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 96 "wrappedkey_lexer.l"
+#line 99 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_TRUSTED; return CKATTR_BOOL; }
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 97 "wrappedkey_lexer.l"
+#line 100 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_WRAP_WITH_TRUSTED; return CKATTR_BOOL; }
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 98 "wrappedkey_lexer.l"
+#line 101 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_WRAP_TEMPLATE; return CKATTR_TEMPLATE; }
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 99 "wrappedkey_lexer.l"
+#line 102 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_UNWRAP_TEMPLATE; return CKATTR_TEMPLATE; }
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 100 "wrappedkey_lexer.l"
+#line 103 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_DERIVE_TEMPLATE; return CKATTR_TEMPLATE; }
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 101 "wrappedkey_lexer.l"
+#line 104 "wrappedkey_lexer.l"
 { yylval.ckattr = CKA_ALLOWED_MECHANISMS; return CKATTR_ALLOWEDMECH; }
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 103 "wrappedkey_lexer.l"
+#line 106 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_GENERIC_SECRET; return KEYTYPE; }
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 104 "wrappedkey_lexer.l"
+#line 107 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_DES           ; return KEYTYPE; }
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 105 "wrappedkey_lexer.l"
+#line 108 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_DES2          ; return KEYTYPE; }
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 106 "wrappedkey_lexer.l"
+#line 109 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_DES3          ; return KEYTYPE; }
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 107 "wrappedkey_lexer.l"
+#line 110 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_AES           ; return KEYTYPE; }
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 108 "wrappedkey_lexer.l"
+#line 111 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_MD5_HMAC      ; return KEYTYPE; }
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 109 "wrappedkey_lexer.l"
+#line 112 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_SHA_1_HMAC    ; return KEYTYPE; }
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 110 "wrappedkey_lexer.l"
+#line 113 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_RIPEMD128_HMAC; return KEYTYPE; }
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 111 "wrappedkey_lexer.l"
+#line 114 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_RIPEMD160_HMAC; return KEYTYPE; }
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 112 "wrappedkey_lexer.l"
+#line 115 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_SHA256_HMAC   ; return KEYTYPE; }
 	YY_BREAK
 case 63:
 YY_RULE_SETUP
-#line 113 "wrappedkey_lexer.l"
+#line 116 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_SHA384_HMAC   ; return KEYTYPE; }
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 114 "wrappedkey_lexer.l"
+#line 117 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_SHA512_HMAC   ; return KEYTYPE; }
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 115 "wrappedkey_lexer.l"
+#line 118 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_SHA224_HMAC   ; return KEYTYPE; }
 	YY_BREAK
 case 66:
 YY_RULE_SETUP
-#line 116 "wrappedkey_lexer.l"
+#line 119 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_RSA           ; return KEYTYPE; }
 	YY_BREAK
 case 67:
 YY_RULE_SETUP
-#line 117 "wrappedkey_lexer.l"
+#line 120 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_DH            ; return KEYTYPE; }
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 118 "wrappedkey_lexer.l"
+#line 121 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_DSA           ; return KEYTYPE; }
 	YY_BREAK
 case 69:
 YY_RULE_SETUP
-#line 119 "wrappedkey_lexer.l"
+#line 122 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_EC            ; return KEYTYPE; }
 	YY_BREAK
 case 70:
 YY_RULE_SETUP
-#line 120 "wrappedkey_lexer.l"
+#line 123 "wrappedkey_lexer.l"
 { yylval.val_key = CKK_EC_EDWARDS    ; return KEYTYPE; }
 	YY_BREAK
 case 71:
 YY_RULE_SETUP
-#line 122 "wrappedkey_lexer.l"
+#line 125 "wrappedkey_lexer.l"
 { yylval.val_cls = CKO_DATA ; return OCLASS; }
 	YY_BREAK
 case 72:
 YY_RULE_SETUP
-#line 123 "wrappedkey_lexer.l"
+#line 126 "wrappedkey_lexer.l"
 { yylval.val_cls = CKO_CERTIFICATE ; return OCLASS; }
 	YY_BREAK
 case 73:
 YY_RULE_SETUP
-#line 124 "wrappedkey_lexer.l"
+#line 127 "wrappedkey_lexer.l"
 { yylval.val_cls = CKO_PUBLIC_KEY ; return OCLASS; }
 	YY_BREAK
 case 74:
 YY_RULE_SETUP
-#line 125 "wrappedkey_lexer.l"
+#line 128 "wrappedkey_lexer.l"
 { yylval.val_cls = CKO_PRIVATE_KEY ; return OCLASS; }
 	YY_BREAK
 case 75:
 YY_RULE_SETUP
-#line 126 "wrappedkey_lexer.l"
+#line 129 "wrappedkey_lexer.l"
 { yylval.val_cls = CKO_SECRET_KEY ; return OCLASS; }
 	YY_BREAK
 case 76:
 YY_RULE_SETUP
-#line 127 "wrappedkey_lexer.l"
+#line 130 "wrappedkey_lexer.l"
 { yylval.val_cls = CKO_HW_FEATURE ; return OCLASS; }
 	YY_BREAK
 case 77:
 YY_RULE_SETUP
-#line 128 "wrappedkey_lexer.l"
+#line 131 "wrappedkey_lexer.l"
 { yylval.val_cls = CKO_DOMAIN_PARAMETERS ; return OCLASS; }
 	YY_BREAK
 case 78:
 YY_RULE_SETUP
-#line 129 "wrappedkey_lexer.l"
+#line 132 "wrappedkey_lexer.l"
 { yylval.val_cls = CKO_MECHANISM ; return OCLASS; }
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
-#line 130 "wrappedkey_lexer.l"
+#line 133 "wrappedkey_lexer.l"
 { yylval.val_cls = CKO_OTP_KEY ; return OCLASS; }
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 132 "wrappedkey_lexer.l"
+#line 135 "wrappedkey_lexer.l"
 { return PARAMMGF; }
 	YY_BREAK
 case 81:
 YY_RULE_SETUP
-#line 133 "wrappedkey_lexer.l"
+#line 136 "wrappedkey_lexer.l"
 { yylval.val_mgf = CKG_MGF1_SHA1; return MGFTYPE; }
 	YY_BREAK
 case 82:
 YY_RULE_SETUP
-#line 134 "wrappedkey_lexer.l"
+#line 137 "wrappedkey_lexer.l"
 { yylval.val_mgf = CKG_MGF1_SHA224; return MGFTYPE; }
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
-#line 135 "wrappedkey_lexer.l"
+#line 138 "wrappedkey_lexer.l"
 { yylval.val_mgf = CKG_MGF1_SHA256; return MGFTYPE; }
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
-#line 136 "wrappedkey_lexer.l"
+#line 139 "wrappedkey_lexer.l"
 { yylval.val_mgf = CKG_MGF1_SHA384; return MGFTYPE; }
 	YY_BREAK
 case 85:
 YY_RULE_SETUP
-#line 137 "wrappedkey_lexer.l"
+#line 140 "wrappedkey_lexer.l"
 { yylval.val_mgf = CKG_MGF1_SHA512; return MGFTYPE; }
 	YY_BREAK
 case 86:
 YY_RULE_SETUP
-#line 139 "wrappedkey_lexer.l"
+#line 142 "wrappedkey_lexer.l"
 { return PARAMHASH; }
 	YY_BREAK
 case 87:
 YY_RULE_SETUP
-#line 141 "wrappedkey_lexer.l"
+#line 144 "wrappedkey_lexer.l"
 { yylval.val_mech = pkcs11_get_mechanism_type_from_name(yytext);
                      if (yylval.val_mech==0xFFFFFFFF) {
 			yyerror(NULL, "Unknown mechanism identifier <%s>", yytext);
@@ -1891,67 +1887,67 @@ YY_RULE_SETUP
 	YY_BREAK
 case 88:
 YY_RULE_SETUP
-#line 149 "wrappedkey_lexer.l"
+#line 152 "wrappedkey_lexer.l"
 { return PARAMLABEL; }
 	YY_BREAK
 case 89:
 YY_RULE_SETUP
-#line 150 "wrappedkey_lexer.l"
+#line 153 "wrappedkey_lexer.l"
 { return PARAMIV; }
 	YY_BREAK
 case 90:
 YY_RULE_SETUP
-#line 151 "wrappedkey_lexer.l"
+#line 154 "wrappedkey_lexer.l"
 { return PARAMFLAVOUR; }
 	YY_BREAK
 case 91:
 YY_RULE_SETUP
-#line 152 "wrappedkey_lexer.l"
+#line 155 "wrappedkey_lexer.l"
 { yylval.val_mech = CKM_NSS_AES_KEY_WRAP_PAD; return CKMECH; }
 	YY_BREAK
 case 92:
 YY_RULE_SETUP
-#line 153 "wrappedkey_lexer.l"
+#line 156 "wrappedkey_lexer.l"
 { return PARAMOUTER; }
 	YY_BREAK
 case 93:
 YY_RULE_SETUP
-#line 154 "wrappedkey_lexer.l"
+#line 157 "wrappedkey_lexer.l"
 { return PARAMINNER; }
 	YY_BREAK
 case 94:
 YY_RULE_SETUP
-#line 156 "wrappedkey_lexer.l"
+#line 159 "wrappedkey_lexer.l"
 { return WRAPPINGJOBHEADER; }
 	YY_BREAK
 case 95:
 YY_RULE_SETUP
-#line 157 "wrappedkey_lexer.l"
+#line 160 "wrappedkey_lexer.l"
 { return P_WRAPPINGKEY; }
 	YY_BREAK
 case 96:
 YY_RULE_SETUP
-#line 158 "wrappedkey_lexer.l"
+#line 161 "wrappedkey_lexer.l"
 { return P_FILENAME; }
 	YY_BREAK
 case 97:
 YY_RULE_SETUP
-#line 159 "wrappedkey_lexer.l"
+#line 162 "wrappedkey_lexer.l"
 { return P_ALGORITHM; }
 	YY_BREAK
 case 98:
 YY_RULE_SETUP
-#line 161 "wrappedkey_lexer.l"
+#line 164 "wrappedkey_lexer.l"
 { yylval.val_bool = 1; return TOK_BOOLEAN; }
 	YY_BREAK
 case 99:
 YY_RULE_SETUP
-#line 162 "wrappedkey_lexer.l"
+#line 165 "wrappedkey_lexer.l"
 { yylval.val_bool = 0; return TOK_BOOLEAN; }
 	YY_BREAK
 case 100:
 YY_RULE_SETUP
-#line 165 "wrappedkey_lexer.l"
+#line 168 "wrappedkey_lexer.l"
 {   if(strlen(yytext)%2==1) {
 			yyerror(NULL, "Invalid hexadecimal string <%s>: odd length", yytext);
 			yyterminate();
@@ -1982,32 +1978,32 @@ YY_RULE_SETUP
 	YY_BREAK
 case 101:
 YY_RULE_SETUP
-#line 193 "wrappedkey_lexer.l"
+#line 196 "wrappedkey_lexer.l"
 { memcpy(yylval.val_date.as_buffer, yytext, 8); return TOK_DATE; }
 	YY_BREAK
 case 102:
 YY_RULE_SETUP
-#line 195 "wrappedkey_lexer.l"
+#line 198 "wrappedkey_lexer.l"
 { yylval.val_dottednumber = strdup(yytext); return DOTTEDNUMBER; }
 	YY_BREAK
 case 103:
 /* rule 103 can match eol */
 YY_RULE_SETUP
-#line 197 "wrappedkey_lexer.l"
+#line 200 "wrappedkey_lexer.l"
 { /* ignore whitespace */ }
 	YY_BREAK
 case 104:
 YY_RULE_SETUP
-#line 199 "wrappedkey_lexer.l"
+#line 202 "wrappedkey_lexer.l"
 { return yytext[0]; } /* catch-all http://stackoverflow.com/questions/18837828/how-should-i-handle-lexical-errors-in-my-flex-lexer */
 	YY_BREAK
 /* gives it back to bison, so error comes from parser */
 case 105:
 YY_RULE_SETUP
-#line 202 "wrappedkey_lexer.l"
+#line 205 "wrappedkey_lexer.l"
 ECHO;
 	YY_BREAK
-#line 2011 "wrappedkey_lexer.c"
+#line 2006 "wrappedkey_lexer.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2086,7 +2082,7 @@ case YY_STATE_EOF(INITIAL):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -2139,6 +2135,7 @@ case YY_STATE_EOF(INITIAL):
 			"fatal flex scanner internal error--no action found" );
 	} /* end of action switch */
 		} /* end of scanning one token */
+	} /* end of user's declarations */
 } /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
@@ -2181,7 +2178,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -2194,7 +2191,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2208,7 +2205,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2217,11 +2214,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -2249,7 +2247,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart(yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -2263,12 +2261,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -2302,9 +2303,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 817 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -2330,15 +2331,16 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 817 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 816);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
 
 #ifndef YY_NO_UNPUT
+
     static void yyunput (int c, char * yy_bp )
 {
 	char *yy_cp;
@@ -2351,7 +2353,7 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		yy_size_t number_to_move = (yy_n_chars) + 2;
+		int number_to_move = (yy_n_chars) + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -2363,7 +2365,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -2379,7 +2381,8 @@ static int yy_get_next_buffer (void)
 	(yy_hold_char) = *yy_cp;
 	(yy_c_buf_p) = yy_cp;
 }
-#endif	/* ifndef YY_NO_UNPUT */
+
+#endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
@@ -2405,7 +2408,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -2422,14 +2425,18 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart(yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap( ) )
+					if ( yywrap(  ) )
+#ifdef YY_FLEX_LEX_COMPAT
+						return 0;
+#else
 						return EOF;
+#endif
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -2453,7 +2460,7 @@ static int yy_get_next_buffer (void)
 
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = (c == '\n');
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_at_bol )
-		   
+		
     yylineno++;
 ;
 
@@ -2472,11 +2479,11 @@ static int yy_get_next_buffer (void)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer(yyin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
@@ -2504,7 +2511,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -2532,7 +2539,7 @@ static void yy_load_buffer_state  (void)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
@@ -2541,13 +2548,13 @@ static void yy_load_buffer_state  (void)
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
@@ -2566,9 +2573,9 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
@@ -2580,7 +2587,7 @@ static void yy_load_buffer_state  (void)
 {
 	int oerrno = errno;
     
-	yy_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -2623,7 +2630,7 @@ static void yy_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -2654,7 +2661,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -2673,7 +2680,7 @@ void yypop_buffer_state (void)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -2691,15 +2698,15 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1;
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -2708,7 +2715,7 @@ static void yyensure_buffer_stack (void)
 	if ((yy_buffer_stack_top) >= ((yy_buffer_stack_max)) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
-		int grow_size = 8 /* arbitrary grow size */;
+		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
@@ -2728,7 +2735,7 @@ static void yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
@@ -2738,23 +2745,23 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
@@ -2767,10 +2774,10 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return yy_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
@@ -2780,16 +2787,16 @@ YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yyalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -2798,7 +2805,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -2814,9 +2821,9 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-    	(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2844,7 +2851,7 @@ static void yy_fatal_error (yyconst char* msg )
  */
 int yyget_lineno  (void)
 {
-        
+    
     return yylineno;
 }
 
@@ -2867,7 +2874,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-yy_size_t yyget_leng  (void)
+int yyget_leng  (void)
 {
         return yyleng;
 }
@@ -2882,29 +2889,29 @@ char *yyget_text  (void)
 }
 
 /** Set the current line number.
- * @param line_number
+ * @param _line_number line number
  * 
  */
-void yyset_lineno (int  line_number )
+void yyset_lineno (int  _line_number )
 {
     
-    yylineno = line_number;
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
- * @param in_str A readable stream.
+ * @param _in_str A readable stream.
  * 
  * @see yy_switch_to_buffer
  */
-void yyset_in (FILE *  in_str )
+void yyset_in (FILE *  _in_str )
 {
-        yyin = in_str ;
+        yyin = _in_str ;
 }
 
-void yyset_out (FILE *  out_str )
+void yyset_out (FILE *  _out_str )
 {
-        yyout = out_str ;
+        yyout = _out_str ;
 }
 
 int yyget_debug  (void)
@@ -2912,9 +2919,9 @@ int yyget_debug  (void)
         return yy_flex_debug;
 }
 
-void yyset_debug (int  bdebug )
+void yyset_debug (int  _bdebug )
 {
-        yy_flex_debug = bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
@@ -2926,10 +2933,10 @@ static int yy_init_globals (void)
     /* We do not touch yylineno unless the option is enabled. */
     yylineno =  1;
     
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
@@ -2938,8 +2945,8 @@ static int yy_init_globals (void)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2954,7 +2961,7 @@ int yylex_destroy  (void)
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state();
 	}
@@ -2975,8 +2982,9 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
+		
 	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
@@ -2984,7 +2992,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -2996,11 +3004,12 @@ static int yy_flex_strlen (yyconst char * s )
 
 void *yyalloc (yy_size_t  size )
 {
-	return (void *) malloc( size );
+			return malloc(size);
 }
 
 void *yyrealloc  (void * ptr, yy_size_t  size )
 {
+		
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -3008,18 +3017,17 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void yyfree (void * ptr )
 {
-	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-#line 202 "wrappedkey_lexer.l"
-
+#line 205 "wrappedkey_lexer.l"
 
 
 

--- a/lib/wrappedkey_lexer.h
+++ b/lib/wrappedkey_lexer.h
@@ -2,7 +2,9 @@
 #define yyHEADER_H 1
 #define yyIN_HEADER 1
 
-#line 6 "wrappedkey_lexer.h"
+#include <config.h>
+
+#line 7 "wrappedkey_lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -10,23 +12,13 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 37
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
-
-#if defined(__FreeBSD__)
-#ifndef __STDC_LIMIT_MACROS
-#define	__STDC_LIMIT_MACROS
-#endif
-#include <sys/cdefs.h>
-#include <stdint.h>
-#else
-#define	__dead2
-#endif
 
 /* begin standard C headers. */
 #include <stdio.h>
@@ -97,34 +89,36 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 #ifndef YY_TYPEDEF_YY_BUFFER_STATE
@@ -137,7 +131,7 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
@@ -153,12 +147,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -181,7 +175,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -192,30 +186,33 @@ struct yy_buffer_state
 	};
 #endif /* !YY_STRUCT_YY_BUFFER_STATE */
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 /* Begin user sect3 */
 
-#define yywrap() 1
+#define yywrap() (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
 
 extern int yylineno;
 
 extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
 #define yytext_ptr yytext
 
 #ifdef YY_HEADER_EXPORT_START_CONDITIONS
@@ -242,31 +239,31 @@ extern char *yytext;
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -274,18 +271,18 @@ void yyset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
@@ -294,7 +291,12 @@ static int yy_flex_strlen (yyconst char * );
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Number of entries by which start-condition stack grows. */
@@ -327,9 +329,154 @@ extern int yylex (void);
 #undef YY_DECL
 #endif
 
-#line 202 "wrappedkey_lexer.l"
+#ifndef yy_create_buffer_ALREADY_DEFINED
+#undef yy_create_buffer
+#endif
+#ifndef yy_delete_buffer_ALREADY_DEFINED
+#undef yy_delete_buffer
+#endif
+#ifndef yy_scan_buffer_ALREADY_DEFINED
+#undef yy_scan_buffer
+#endif
+#ifndef yy_scan_string_ALREADY_DEFINED
+#undef yy_scan_string
+#endif
+#ifndef yy_scan_bytes_ALREADY_DEFINED
+#undef yy_scan_bytes
+#endif
+#ifndef yy_init_buffer_ALREADY_DEFINED
+#undef yy_init_buffer
+#endif
+#ifndef yy_flush_buffer_ALREADY_DEFINED
+#undef yy_flush_buffer
+#endif
+#ifndef yy_load_buffer_state_ALREADY_DEFINED
+#undef yy_load_buffer_state
+#endif
+#ifndef yy_switch_to_buffer_ALREADY_DEFINED
+#undef yy_switch_to_buffer
+#endif
+#ifndef yypush_buffer_state_ALREADY_DEFINED
+#undef yypush_buffer_state
+#endif
+#ifndef yypop_buffer_state_ALREADY_DEFINED
+#undef yypop_buffer_state
+#endif
+#ifndef yyensure_buffer_stack_ALREADY_DEFINED
+#undef yyensure_buffer_stack
+#endif
+#ifndef yylex_ALREADY_DEFINED
+#undef yylex
+#endif
+#ifndef yyrestart_ALREADY_DEFINED
+#undef yyrestart
+#endif
+#ifndef yylex_init_ALREADY_DEFINED
+#undef yylex_init
+#endif
+#ifndef yylex_init_extra_ALREADY_DEFINED
+#undef yylex_init_extra
+#endif
+#ifndef yylex_destroy_ALREADY_DEFINED
+#undef yylex_destroy
+#endif
+#ifndef yyget_debug_ALREADY_DEFINED
+#undef yyget_debug
+#endif
+#ifndef yyset_debug_ALREADY_DEFINED
+#undef yyset_debug
+#endif
+#ifndef yyget_extra_ALREADY_DEFINED
+#undef yyget_extra
+#endif
+#ifndef yyset_extra_ALREADY_DEFINED
+#undef yyset_extra
+#endif
+#ifndef yyget_in_ALREADY_DEFINED
+#undef yyget_in
+#endif
+#ifndef yyset_in_ALREADY_DEFINED
+#undef yyset_in
+#endif
+#ifndef yyget_out_ALREADY_DEFINED
+#undef yyget_out
+#endif
+#ifndef yyset_out_ALREADY_DEFINED
+#undef yyset_out
+#endif
+#ifndef yyget_leng_ALREADY_DEFINED
+#undef yyget_leng
+#endif
+#ifndef yyget_text_ALREADY_DEFINED
+#undef yyget_text
+#endif
+#ifndef yyget_lineno_ALREADY_DEFINED
+#undef yyget_lineno
+#endif
+#ifndef yyset_lineno_ALREADY_DEFINED
+#undef yyset_lineno
+#endif
+#ifndef yyget_column_ALREADY_DEFINED
+#undef yyget_column
+#endif
+#ifndef yyset_column_ALREADY_DEFINED
+#undef yyset_column
+#endif
+#ifndef yywrap_ALREADY_DEFINED
+#undef yywrap
+#endif
+#ifndef yyget_lval_ALREADY_DEFINED
+#undef yyget_lval
+#endif
+#ifndef yyset_lval_ALREADY_DEFINED
+#undef yyset_lval
+#endif
+#ifndef yyget_lloc_ALREADY_DEFINED
+#undef yyget_lloc
+#endif
+#ifndef yyset_lloc_ALREADY_DEFINED
+#undef yyset_lloc
+#endif
+#ifndef yyalloc_ALREADY_DEFINED
+#undef yyalloc
+#endif
+#ifndef yyrealloc_ALREADY_DEFINED
+#undef yyrealloc
+#endif
+#ifndef yyfree_ALREADY_DEFINED
+#undef yyfree
+#endif
+#ifndef yytext_ALREADY_DEFINED
+#undef yytext
+#endif
+#ifndef yyleng_ALREADY_DEFINED
+#undef yyleng
+#endif
+#ifndef yyin_ALREADY_DEFINED
+#undef yyin
+#endif
+#ifndef yyout_ALREADY_DEFINED
+#undef yyout
+#endif
+#ifndef yy_flex_debug_ALREADY_DEFINED
+#undef yy_flex_debug
+#endif
+#ifndef yylineno_ALREADY_DEFINED
+#undef yylineno
+#endif
+#ifndef yytables_fload_ALREADY_DEFINED
+#undef yytables_fload
+#endif
+#ifndef yytables_destroy_ALREADY_DEFINED
+#undef yytables_destroy
+#endif
+#ifndef yyTABLES_NAME_ALREADY_DEFINED
+#undef yyTABLES_NAME
+#endif
+
+#line 205 "wrappedkey_lexer.l"
 
 
-#line 334 "wrappedkey_lexer.h"
+#line 480 "wrappedkey_lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/lib/wrappedkey_lexer.l
+++ b/lib/wrappedkey_lexer.l
@@ -21,8 +21,11 @@
 %option header-file="wrappedkey_lexer.h"
 %option never-interactive
 
+%top{
+#include <config.h>
+}
+
 %{
-#include "config.h"
 #include <stdarg.h>
 #include "wrappedkey_parser.h"
 

--- a/lib/wrappedkey_parser.c
+++ b/lib/wrappedkey_parser.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.7.6.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -46,10 +46,10 @@
    USER NAME SPACE" below.  */
 
 /* Identify Bison output, and Bison version.  */
-#define YYBISON 30706
+#define YYBISON 30802
 
 /* Bison version string.  */
-#define YYBISON_VERSION "3.7.6"
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -69,6 +69,7 @@
 /* First part of user prologue.  */
 #line 26 "wrappedkey_parser.y"
 
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -80,7 +81,7 @@ int parsing_envelope= 0;
 int envelope_keyindex=0;
 
 
-#line 84 "wrappedkey_parser.c"
+#line 85 "wrappedkey_parser.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -115,7 +116,7 @@ int envelope_keyindex=0;
 extern int yydebug;
 #endif
 /* "%code requires" blocks.  */
-#line 39 "wrappedkey_parser.y"
+#line 40 "wrappedkey_parser.y"
 
 
 #include "pkcs11lib.h"
@@ -125,7 +126,7 @@ extern void yyerror(wrappedKeyCtx *ctx, const char *s, ...);
 extern int yylex(void);
 
 
-#line 129 "wrappedkey_parser.c"
+#line 130 "wrappedkey_parser.c"
 
 /* Token kinds.  */
 #ifndef YYTOKENTYPE
@@ -184,7 +185,7 @@ extern int yylex(void);
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 52 "wrappedkey_parser.y"
+#line 53 "wrappedkey_parser.y"
 
     CK_ATTRIBUTE_TYPE ckattr;
     CK_KEY_TYPE val_key;
@@ -208,13 +209,13 @@ union YYSTYPE
 	    char month[2];
 	    char day[2];
 	} as_ck_date;
-        char as_buffer[8];
+	char as_buffer[8];
     } val_date;
 
     unsigned char *val_pem;	/* used to hold PEM-encoded blocks */
     char *val_dottednumber;
 
-#line 218 "wrappedkey_parser.c"
+#line 219 "wrappedkey_parser.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -225,7 +226,9 @@ typedef union YYSTYPE YYSTYPE;
 
 extern YYSTYPE yylval;
 
+
 int yyparse (wrappedKeyCtx *ctx);
+
 
 #endif /* !YY_YY_WRAPPEDKEY_PARSER_H_INCLUDED  */
 /* Symbol kind.  */
@@ -496,12 +499,18 @@ typedef int yy_state_fast_t;
 # define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                            \
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
     _Pragma ("GCC diagnostic push")                                     \
     _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
 # define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
@@ -719,21 +728,21 @@ static const yytype_int8 yytranslate[] =
 };
 
 #if YYDEBUG
-  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   113,   113,   114,   115,   118,   119,   130,   133,   134,
-     135,   138,   148,   158,   159,   162,   163,   166,   167,   170,
-     171,   183,   184,   195,   196,   199,   206,   215,   222,   231,
-     238,   246,   245,   276,   291,   292,   295,   307,   308,   309,
-     310,   311,   312,   315,   318,   331,   332,   335,   336,   339,
-     352,   353,   356,   357,   360,   367,   374,   385,   386,   390,
-     403,   404,   408,   409,   412,   425,   426,   430,   443,   444,
-     449,   450,   453,   466,   467,   470,   471,   474,   483,   485,
-     484,   495,   508,   509,   512,   513,   517,   516,   522,   521,
-     528,   529,   532,   533,   534,   539,   542,   552,   553,   557,
-     564,   573,   580,   589,   596,   604,   603,   640,   643,   644,
-     647,   656,   665
+       0,   114,   114,   115,   116,   119,   120,   131,   134,   135,
+     136,   139,   149,   159,   160,   163,   164,   167,   168,   171,
+     172,   184,   185,   196,   197,   200,   207,   216,   223,   232,
+     239,   247,   246,   277,   292,   293,   296,   308,   309,   310,
+     311,   312,   313,   316,   319,   332,   333,   336,   337,   340,
+     353,   354,   357,   358,   361,   368,   375,   386,   387,   391,
+     404,   405,   409,   410,   413,   426,   427,   431,   444,   445,
+     450,   451,   454,   467,   468,   471,   472,   475,   484,   486,
+     485,   496,   509,   510,   513,   514,   518,   517,   523,   522,
+     529,   530,   533,   534,   535,   540,   543,   553,   554,   558,
+     565,   574,   581,   590,   597,   605,   604,   641,   644,   645,
+     648,   657,   666
 };
 #endif
 
@@ -780,20 +789,6 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_int16 yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
-     285,   286,   287,   288,   289,   290,   291,   292,   293,   294,
-     295,   296,   297,    58,   123,   125,    47,    40,    41,    44,
-      61
-};
-#endif
-
 #define YYPACT_NINF (-57)
 
 #define yypact_value_is_default(Yyn) \
@@ -804,8 +799,8 @@ static const yytype_int16 yytoknum[] =
 #define yytable_value_is_error(Yyn) \
   0
 
-  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-     STATE-NUM.  */
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
       -5,   -37,   -29,    23,    18,    29,   -57,    13,   -13,   -15,
@@ -831,9 +826,9 @@ static const yytype_int16 yypact[] =
      -57,   -57,   -57
 };
 
-  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
-     Performed when YYTABLE does not specify something else to do.  Zero
-     means the default is an error.  */
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
        0,     0,     0,     0,     0,     0,     4,     0,     0,     0,
@@ -859,7 +854,7 @@ static const yytype_int8 yydefact[] =
       93,    94,    89
 };
 
-  /* YYPGOTO[NTERM-NUM].  */
+/* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
      -57,   -57,   -57,   -57,   -57,    81,    84,   -57,   150,   -57,
@@ -870,7 +865,7 @@ static const yytype_int16 yypgoto[] =
       33,   -56,   -57,   -57,   -57,   158
 };
 
-  /* YYDEFGOTO[NTERM-NUM].  */
+/* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_uint8 yydefgoto[] =
 {
        0,     4,     5,    26,    61,    62,    63,    27,    28,    29,
@@ -881,9 +876,9 @@ static const yytype_uint8 yydefgoto[] =
       57,    58,   162,     6,    12,    13
 };
 
-  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
-     positive, shift that token.  If negative, reduce the rule whose
-     number is the opposite.  If YYTABLE_NINF, syntax error.  */
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[] =
 {
       66,   115,     1,     2,    59,    60,     7,   130,    15,    16,
@@ -932,8 +927,8 @@ static const yytype_uint8 yycheck[] =
      194,    50,    50,   194,   191,   162,    38,   173
 };
 
-  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-     symbol of state STATE-NUM.  */
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
 static const yytype_int8 yystos[] =
 {
        0,     7,     8,    39,    52,    53,   104,    43,    43,    40,
@@ -959,7 +954,7 @@ static const yytype_int8 yystos[] =
       81,    84,    98
 };
 
-  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
        0,    51,    52,    52,    52,    53,    53,    54,    55,    55,
@@ -976,7 +971,7 @@ static const yytype_int8 yyr1[] =
      106,   106,   106
 };
 
-  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
        0,     2,     2,     3,     1,     3,     3,     2,     1,     2,
@@ -1002,6 +997,7 @@ enum { YYENOMEM = -2 };
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
 #define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
 
 
 #define YYRECOVERING()  (!!yyerrstatus)
@@ -1042,10 +1038,7 @@ do {                                            \
     YYFPRINTF Args;                             \
 } while (0)
 
-/* This macro is provided for backward compatibility. */
-# ifndef YY_LOCATION_PRINT
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
+
 
 
 # define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
@@ -1073,10 +1066,6 @@ yy_symbol_value_print (FILE *yyo,
   YY_USE (ctx);
   if (!yyvaluep)
     return;
-# ifdef YYPRINT
-  if (yykind < YYNTOKENS)
-    YYPRINT (yyo, yytoknum[yykind], *yyvaluep);
-# endif
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   YY_USE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
@@ -1532,6 +1521,7 @@ yyparse (wrappedKeyCtx *ctx)
   YYDPRINTF ((stderr, "Starting parse\n"));
 
   yychar = YYEMPTY; /* Cause a token to be read.  */
+
   goto yysetstate;
 
 
@@ -1557,7 +1547,7 @@ yysetstate:
 
   if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
-    goto yyexhaustedlab;
+    YYNOMEM;
 #else
     {
       /* Get the current used size of the three stacks, in elements.  */
@@ -1585,7 +1575,7 @@ yysetstate:
 # else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-        goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
         yystacksize = YYMAXDEPTH;
@@ -1596,7 +1586,7 @@ yysetstate:
           YY_CAST (union yyalloc *,
                    YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
-          goto yyexhaustedlab;
+          YYNOMEM;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
 #  undef YYSTACK_RELOCATE
@@ -1617,6 +1607,7 @@ yysetstate:
         YYABORT;
     }
 #endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
+
 
   if (yystate == YYFINAL)
     YYACCEPT;
@@ -1730,7 +1721,7 @@ yyreduce:
   switch (yyn)
     {
   case 6: /* headers: GRAMMAR_VERSION ':' DOTTEDNUMBER  */
-#line 120 "wrappedkey_parser.y"
+#line 121 "wrappedkey_parser.y"
                 {
 		    if(strcmp((yyvsp[0].val_dottednumber),SUPPORTED_GRAMMAR_VERSION)>0) {
 			yyerror(ctx,"Grammar version (%s) not supported, max supported is %s please update pkcs11-tools\n", (yyvsp[0].val_dottednumber), SUPPORTED_GRAMMAR_VERSION);
@@ -1739,35 +1730,35 @@ yyreduce:
 		    }
 		    free((yyvsp[0].val_dottednumber));
 		}
-#line 1743 "wrappedkey_parser.c"
+#line 1734 "wrappedkey_parser.c"
     break;
 
   case 11: /* innerblock: INNER  */
-#line 139 "wrappedkey_parser.y"
+#line 140 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_append_cryptogram(ctx, (yyvsp[0].val_pem), WRAPPEDKEYCTX_INNER_KEY_INDEX)!=rc_ok) {
 			yyerror(ctx,"Error when parsing encrypted key cryptogram (inner)");
 			YYERROR;
 		    }
-                    free((yyvsp[0].val_pem));	/* free up mem */
+		    free((yyvsp[0].val_pem));	/* free up mem */
 		}
-#line 1755 "wrappedkey_parser.c"
+#line 1746 "wrappedkey_parser.c"
     break;
 
   case 12: /* outerblock: OUTER  */
-#line 149 "wrappedkey_parser.y"
+#line 150 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_append_cryptogram(ctx, (yyvsp[0].val_pem), WRAPPEDKEYCTX_OUTER_KEY_INDEX)!=rc_ok) {
 			yyerror(ctx,"Error when parsing encrypted key cryptogram (outer)");
 			YYERROR;
 		    }
-                    free((yyvsp[0].val_pem));	/* free up mem */
+		    free((yyvsp[0].val_pem));	/* free up mem */
 		}
-#line 1767 "wrappedkey_parser.c"
+#line 1758 "wrappedkey_parser.c"
     break;
 
   case 20: /* metastmt: GRAMMAR_VERSION ':' DOTTEDNUMBER  */
-#line 172 "wrappedkey_parser.y"
+#line 173 "wrappedkey_parser.y"
                 {
 		    if(strcmp((yyvsp[0].val_dottednumber),SUPPORTED_GRAMMAR_VERSION)>0) {
 			yyerror(ctx,
@@ -1779,35 +1770,35 @@ yyreduce:
 		    }
 		    free((yyvsp[0].val_dottednumber));
 		}
-#line 1783 "wrappedkey_parser.c"
+#line 1774 "wrappedkey_parser.c"
     break;
 
   case 22: /* metastmt: WRAPPING_KEY ':' STRING  */
-#line 185 "wrappedkey_parser.y"
+#line 186 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_set_wrapping_key(ctx, (yyvsp[0].val_str).val, (yyvsp[0].val_str).len)!=rc_ok) {
-		        yyerror(ctx,"Parsing error with wrapping key identifier.");
+			yyerror(ctx,"Parsing error with wrapping key identifier.");
 			free((yyvsp[0].val_str).val);
-                        YYERROR;
-                    }
-                    free((yyvsp[0].val_str).val);
+			YYERROR;
+		    }
+		    free((yyvsp[0].val_str).val);
 		}
-#line 1796 "wrappedkey_parser.c"
+#line 1787 "wrappedkey_parser.c"
     break;
 
   case 25: /* assignstmt: CKATTR_BOOL ':' TOK_BOOLEAN  */
-#line 200 "wrappedkey_parser.y"
+#line 201 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, (yyvsp[-2].ckattr), &(yyvsp[0].val_bool), sizeof(CK_BBOOL) )!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign boolean value.");
 			YYERROR;
 		    }
 		}
-#line 1807 "wrappedkey_parser.c"
+#line 1798 "wrappedkey_parser.c"
     break;
 
   case 26: /* assignstmt: CKATTR_STR ':' STRING  */
-#line 207 "wrappedkey_parser.y"
+#line 208 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, (yyvsp[-2].ckattr), (yyvsp[0].val_str).val, (yyvsp[0].val_str).len)!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign bytes value.");
@@ -1816,22 +1807,22 @@ yyreduce:
 		    }
 		    free((yyvsp[0].val_str).val);
 		}
-#line 1820 "wrappedkey_parser.c"
+#line 1811 "wrappedkey_parser.c"
     break;
 
   case 27: /* assignstmt: CKATTR_DATE ':' TOK_DATE  */
-#line 216 "wrappedkey_parser.y"
+#line 217 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, (yyvsp[-2].ckattr), (yyvsp[0].val_date).as_buffer, sizeof(CK_DATE))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign date value.");
 			YYERROR;
 		    }
 		}
-#line 1831 "wrappedkey_parser.c"
+#line 1822 "wrappedkey_parser.c"
     break;
 
   case 28: /* assignstmt: CKATTR_DATE ':' STRING  */
-#line 223 "wrappedkey_parser.y"
+#line 224 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, (yyvsp[-2].ckattr), (yyvsp[0].val_str).val, (yyvsp[0].val_str).len)!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign date value.");
@@ -1840,58 +1831,58 @@ yyreduce:
 		    }
 		    free((yyvsp[0].val_str).val);
 		}
-#line 1844 "wrappedkey_parser.c"
+#line 1835 "wrappedkey_parser.c"
     break;
 
   case 29: /* assignstmt: CKATTR_KEY ':' KEYTYPE  */
-#line 232 "wrappedkey_parser.y"
+#line 233 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, (yyvsp[-2].ckattr), &(yyvsp[0].val_key), sizeof(CK_KEY_TYPE))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign key type value.");
 			YYERROR;
 		    }
 		}
-#line 1855 "wrappedkey_parser.c"
+#line 1846 "wrappedkey_parser.c"
     break;
 
   case 30: /* assignstmt: CKATTR_CLASS ':' OCLASS  */
-#line 239 "wrappedkey_parser.y"
+#line 240 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, (yyvsp[-2].ckattr), &(yyvsp[0].val_cls), sizeof(CK_OBJECT_CLASS))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign object class value.");
 			YYERROR;
 		    }
 		}
-#line 1866 "wrappedkey_parser.c"
+#line 1857 "wrappedkey_parser.c"
     break;
 
   case 31: /* $@1: %empty  */
-#line 246 "wrappedkey_parser.y"
+#line 247 "wrappedkey_parser.y"
                 {
 		    if(ctx->wrpkattribs->level==1) {
 			yyerror(ctx, "***Error: nesting templates not allowed");
 			YYERROR;
 		    }
-                    ctx->wrpkattribs->level++; /*remind we are in a curly brace */
-		    
+		    ctx->wrpkattribs->level++; /*remind we are in a curly brace */
+
 		    ctx->wrpkattribs->current_idx = ctx->wrpkattribs->saved_idx + 1; /*increment current idx from ctx->saved_idx */
 		    if(ctx->wrpkattribs->current_idx>=4) {
 			/* There exist only 3 templates */
 			yyerror(ctx, "***Error: too many templates specified");
 			YYERROR;
-                   } 		    
+		   }
 		}
-#line 1885 "wrappedkey_parser.c"
+#line 1876 "wrappedkey_parser.c"
     break;
 
   case 32: /* assignstmt: CKATTR_TEMPLATE ':' '{' $@1 assignstmts '}'  */
-#line 261 "wrappedkey_parser.y"
+#line 262 "wrappedkey_parser.y"
                 {
 		    if(ctx->wrpkattribs->level==0) {
-		        yyerror(ctx, "***Error: no matching opening curly brace");
+			yyerror(ctx, "***Error: no matching opening curly brace");
 			YYERROR;
-                    }
-                    ctx->wrpkattribs->level--; /*out of curly brace now */
+		    }
+		    ctx->wrpkattribs->level--; /*out of curly brace now */
 
 		    ctx->wrpkattribs->saved_idx = ctx->wrpkattribs->current_idx; /* remember which index we used last */
 		    ctx->wrpkattribs->current_idx = ctx->wrpkattribs->mainlist_idx; /* should be always 0 */
@@ -1899,15 +1890,15 @@ yyreduce:
 		    if(_wrappedkey_parser_wkey_assign_list_to_template(ctx, (yyvsp[-5].ckattr))!=rc_ok) {
 			yyerror(ctx, "Error during parsing, cannot assign attribute list to a template attribute.");
 			YYERROR;
-		    }		    
+		    }
 		}
-#line 1905 "wrappedkey_parser.c"
+#line 1896 "wrappedkey_parser.c"
     break;
 
   case 33: /* assignstmt: CKATTR_ALLOWEDMECH ':' '{' mechanisms '}'  */
-#line 277 "wrappedkey_parser.y"
+#line 278 "wrappedkey_parser.y"
                 {
-	            if( _wrappedkey_parser_wkey_append_attr( ctx,
+		    if( _wrappedkey_parser_wkey_append_attr( ctx,
 							     (yyvsp[-4].ckattr),
 							     pkcs11_wctx_get_allowed_mechanisms(ctx),
 							     pkcs11_wctx_get_allowed_mechanisms_len(ctx))
@@ -1915,25 +1906,25 @@ yyreduce:
 			yyerror(ctx,"Error during parsing, cannot assign object class value.");
 			YYERROR;
 		    }
-		    /* pointer stolen, we must forget it */		
+		    /* pointer stolen, we must forget it */
 		    pkcs11_wctx_forget_mechanisms(ctx);
 		}
-#line 1922 "wrappedkey_parser.c"
+#line 1913 "wrappedkey_parser.c"
     break;
 
   case 36: /* mechanism: CKMECH  */
-#line 296 "wrappedkey_parser.y"
+#line 297 "wrappedkey_parser.y"
                 {
 		    if( _wrappedkey_parser_add_mechanism(ctx, (yyvsp[0].val_mech))!=rc_ok) {
 			yyerror(ctx, "Error during parsing, cannot assign mechanism to allowed mechanisms.");
 			YYERROR;
 		    }
 		}
-#line 1933 "wrappedkey_parser.c"
+#line 1924 "wrappedkey_parser.c"
     break;
 
   case 44: /* pkcs1algoheader: pkcs1algoid  */
-#line 319 "wrappedkey_parser.y"
+#line 320 "wrappedkey_parser.y"
                 {
 		    int keyidx = parsing_envelope ? envelope_keyindex : WRAPPEDKEYCTX_LONE_KEY_INDEX;
 		    if(_wrappedkey_parser_wkey_set_wrapping_alg(ctx, (yyvsp[0].val_wrappingmethod), keyidx)!=rc_ok) {
@@ -1941,17 +1932,17 @@ yyreduce:
 			YYERROR;
 		    }
 		}
-#line 1945 "wrappedkey_parser.c"
+#line 1936 "wrappedkey_parser.c"
     break;
 
   case 46: /* pkcs1algoid: PKCS1ALGO '/' DOTTEDNUMBER  */
-#line 332 "wrappedkey_parser.y"
+#line 333 "wrappedkey_parser.y"
                                            { free((yyvsp[0].val_dottednumber)); }
-#line 1951 "wrappedkey_parser.c"
+#line 1942 "wrappedkey_parser.c"
     break;
 
   case 49: /* oaepalgoheader: oaepalgoid  */
-#line 340 "wrappedkey_parser.y"
+#line 341 "wrappedkey_parser.y"
                 {
 		    int keyidx = parsing_envelope ? envelope_keyindex : WRAPPEDKEYCTX_LONE_KEY_INDEX;
 		    if(_wrappedkey_parser_wkey_set_wrapping_alg(ctx, (yyvsp[0].val_wrappingmethod), keyidx)!=rc_ok) {
@@ -1959,52 +1950,52 @@ yyreduce:
 			YYERROR;
 		    }
 		}
-#line 1963 "wrappedkey_parser.c"
+#line 1954 "wrappedkey_parser.c"
     break;
 
   case 51: /* oaepalgoid: OAEPALGO '/' DOTTEDNUMBER  */
-#line 353 "wrappedkey_parser.y"
+#line 354 "wrappedkey_parser.y"
                                           { free((yyvsp[0].val_dottednumber)); }
-#line 1969 "wrappedkey_parser.c"
+#line 1960 "wrappedkey_parser.c"
     break;
 
   case 54: /* oaepparam: PARAMHASH '=' CKMECH  */
-#line 361 "wrappedkey_parser.y"
+#line 362 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_set_wrapping_param_hash(ctx, (yyvsp[0].val_mech))!=rc_ok) {
 			yyerror(ctx,"Parsing error with specified wrapping algorithm.");
 			YYERROR;
 		    }
 		}
-#line 1980 "wrappedkey_parser.c"
+#line 1971 "wrappedkey_parser.c"
     break;
 
   case 55: /* oaepparam: PARAMMGF '=' MGFTYPE  */
-#line 368 "wrappedkey_parser.y"
+#line 369 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_set_wrapping_param_mgf(ctx, (yyvsp[0].val_mgf))!=rc_ok) {
 			yyerror(ctx,"Parsing error with specified wrapping algorithm.");
 			YYERROR;
 		    }
 		}
-#line 1991 "wrappedkey_parser.c"
+#line 1982 "wrappedkey_parser.c"
     break;
 
   case 56: /* oaepparam: PARAMLABEL '=' STRING  */
-#line 375 "wrappedkey_parser.y"
+#line 376 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_set_wrapping_param_label(ctx, (yyvsp[0].val_str).val, (yyvsp[0].val_str).len)!=rc_ok) {
 			yyerror(ctx,"Parsing error with specified wrapping algorithm.");
-                        free((yyvsp[0].val_str).val);
+			free((yyvsp[0].val_str).val);
 			YYERROR;
 		    }
-                    free((yyvsp[0].val_str).val);
+		    free((yyvsp[0].val_str).val);
 		}
-#line 2004 "wrappedkey_parser.c"
+#line 1995 "wrappedkey_parser.c"
     break;
 
   case 59: /* cbcpadalgoheader: cbcpadalgoid  */
-#line 391 "wrappedkey_parser.y"
+#line 392 "wrappedkey_parser.y"
                 {
 		    int keyidx = parsing_envelope ? envelope_keyindex : WRAPPEDKEYCTX_LONE_KEY_INDEX;
 		    if(_wrappedkey_parser_wkey_set_wrapping_alg(ctx, (yyvsp[0].val_wrappingmethod), keyidx)!=rc_ok) {
@@ -2012,30 +2003,30 @@ yyreduce:
 			YYERROR;
 		    }
 		}
-#line 2016 "wrappedkey_parser.c"
+#line 2007 "wrappedkey_parser.c"
     break;
 
   case 61: /* cbcpadalgoid: CBCPADALGO '/' DOTTEDNUMBER  */
-#line 404 "wrappedkey_parser.y"
+#line 405 "wrappedkey_parser.y"
                                             { free((yyvsp[0].val_dottednumber)); }
-#line 2022 "wrappedkey_parser.c"
+#line 2013 "wrappedkey_parser.c"
     break;
 
   case 64: /* cbcpadparam: PARAMIV '=' STRING  */
-#line 413 "wrappedkey_parser.y"
+#line 414 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_set_wrapping_param_iv(ctx, (yyvsp[0].val_str).val, (yyvsp[0].val_str).len)!=rc_ok) {
 			yyerror(ctx,"Parsing error with specified wrapping algorithm.");
-                        free((yyvsp[0].val_str).val);
+			free((yyvsp[0].val_str).val);
 			YYERROR;
 		    }
-                    free((yyvsp[0].val_str).val);
+		    free((yyvsp[0].val_str).val);
 		}
-#line 2035 "wrappedkey_parser.c"
+#line 2026 "wrappedkey_parser.c"
     break;
 
   case 67: /* rfc3394algoheader: rfc3394algoid  */
-#line 431 "wrappedkey_parser.y"
+#line 432 "wrappedkey_parser.y"
                 {
 		    int keyidx = parsing_envelope ? envelope_keyindex : WRAPPEDKEYCTX_LONE_KEY_INDEX;
 		    if(_wrappedkey_parser_wkey_set_wrapping_alg(ctx, (yyvsp[0].val_wrappingmethod), keyidx)!=rc_ok) {
@@ -2043,17 +2034,17 @@ yyreduce:
 			YYERROR;
 		    }
 		}
-#line 2047 "wrappedkey_parser.c"
+#line 2038 "wrappedkey_parser.c"
     break;
 
   case 69: /* rfc3394algoid: RFC3394ALGO '/' DOTTEDNUMBER  */
-#line 444 "wrappedkey_parser.y"
+#line 445 "wrappedkey_parser.y"
                                              { free((yyvsp[0].val_dottednumber)); }
-#line 2053 "wrappedkey_parser.c"
+#line 2044 "wrappedkey_parser.c"
     break;
 
   case 72: /* rfc5649algoheader: rfc5649algoid  */
-#line 454 "wrappedkey_parser.y"
+#line 455 "wrappedkey_parser.y"
                 {
 		    int keyidx = parsing_envelope ? envelope_keyindex : WRAPPEDKEYCTX_LONE_KEY_INDEX;
 		    if(_wrappedkey_parser_wkey_set_wrapping_alg(ctx, (yyvsp[0].val_wrappingmethod), keyidx)!=rc_ok) {
@@ -2061,45 +2052,45 @@ yyreduce:
 			YYERROR;
 		    }
 		}
-#line 2065 "wrappedkey_parser.c"
+#line 2056 "wrappedkey_parser.c"
     break;
 
   case 74: /* rfc5649algoid: RFC5649ALGO '/' DOTTEDNUMBER  */
-#line 467 "wrappedkey_parser.y"
+#line 468 "wrappedkey_parser.y"
                                              { free((yyvsp[0].val_dottednumber)); }
-#line 2071 "wrappedkey_parser.c"
+#line 2062 "wrappedkey_parser.c"
     break;
 
   case 77: /* rfc5649param: PARAMFLAVOUR '=' CKMECH  */
-#line 475 "wrappedkey_parser.y"
+#line 476 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_set_wrapping_param_flavour(ctx, (yyvsp[0].val_mech))!=rc_ok) {
 			yyerror(ctx,"Parsing error with specified wrapping algorithm flavour.");
 			YYERROR;
 		    }
 		}
-#line 2082 "wrappedkey_parser.c"
+#line 2073 "wrappedkey_parser.c"
     break;
 
   case 79: /* $@2: %empty  */
-#line 485 "wrappedkey_parser.y"
+#line 486 "wrappedkey_parser.y"
                 {
 		    if(++parsing_envelope>1) {
 			yyerror(ctx, "Nested envelope() algorithm not allowed.");
 			YYERROR;
 		    }
 		}
-#line 2093 "wrappedkey_parser.c"
+#line 2084 "wrappedkey_parser.c"
     break;
 
   case 80: /* envelopealgo: envelopealgoheader '(' $@2 envelopeparamlist ')'  */
-#line 492 "wrappedkey_parser.y"
+#line 493 "wrappedkey_parser.y"
                     { --parsing_envelope; }
-#line 2099 "wrappedkey_parser.c"
+#line 2090 "wrappedkey_parser.c"
     break;
 
   case 81: /* envelopealgoheader: envelopealgoid  */
-#line 496 "wrappedkey_parser.y"
+#line 497 "wrappedkey_parser.y"
                 {
 		    int keyidx = parsing_envelope ? envelope_keyindex : WRAPPEDKEYCTX_LONE_KEY_INDEX;
 		    if(_wrappedkey_parser_wkey_set_wrapping_alg(ctx, (yyvsp[0].val_wrappingmethod), keyidx)!=rc_ok) {
@@ -2107,56 +2098,56 @@ yyreduce:
 			YYERROR;
 		    }
 		}
-#line 2111 "wrappedkey_parser.c"
+#line 2102 "wrappedkey_parser.c"
     break;
 
   case 83: /* envelopealgoid: ENVELOPEALGO '/' DOTTEDNUMBER  */
-#line 509 "wrappedkey_parser.y"
+#line 510 "wrappedkey_parser.y"
                                               { free((yyvsp[0].val_dottednumber)); }
-#line 2117 "wrappedkey_parser.c"
+#line 2108 "wrappedkey_parser.c"
     break;
 
   case 86: /* $@3: %empty  */
-#line 517 "wrappedkey_parser.y"
+#line 518 "wrappedkey_parser.y"
                 {
 		    envelope_keyindex = WRAPPEDKEYCTX_OUTER_KEY_INDEX;
 		}
-#line 2125 "wrappedkey_parser.c"
+#line 2116 "wrappedkey_parser.c"
     break;
 
   case 88: /* $@4: %empty  */
-#line 522 "wrappedkey_parser.y"
+#line 523 "wrappedkey_parser.y"
                 {
 		    envelope_keyindex = WRAPPEDKEYCTX_INNER_KEY_INDEX;
 		}
-#line 2133 "wrappedkey_parser.c"
+#line 2124 "wrappedkey_parser.c"
     break;
 
   case 96: /* pubkblock: PUBK  */
-#line 543 "wrappedkey_parser.y"
+#line 544 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_pubk_append_pem(ctx, (yyvsp[0].val_pem))!=rc_ok) {
 			yyerror(ctx,"Error when parsing public key information");
 			YYERROR;
 		    }
-                    free((yyvsp[0].val_pem));	/* free up mem */
+		    free((yyvsp[0].val_pem));	/* free up mem */
 		}
-#line 2145 "wrappedkey_parser.c"
+#line 2136 "wrappedkey_parser.c"
     break;
 
   case 99: /* pubkstmt: CKATTR_BOOL ':' TOK_BOOLEAN  */
-#line 558 "wrappedkey_parser.y"
+#line 559 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, (yyvsp[-2].ckattr), &(yyvsp[0].val_bool), sizeof(CK_BBOOL) )!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign boolean value.");
 			YYERROR;
 		    }
 		}
-#line 2156 "wrappedkey_parser.c"
+#line 2147 "wrappedkey_parser.c"
     break;
 
   case 100: /* pubkstmt: CKATTR_STR ':' STRING  */
-#line 565 "wrappedkey_parser.y"
+#line 566 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, (yyvsp[-2].ckattr), (yyvsp[0].val_str).val, (yyvsp[0].val_str).len)!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign bytes value.");
@@ -2165,22 +2156,22 @@ yyreduce:
 		    }
 		    free((yyvsp[0].val_str).val);
 		}
-#line 2169 "wrappedkey_parser.c"
+#line 2160 "wrappedkey_parser.c"
     break;
 
   case 101: /* pubkstmt: CKATTR_DATE ':' TOK_DATE  */
-#line 574 "wrappedkey_parser.y"
+#line 575 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, (yyvsp[-2].ckattr), (yyvsp[0].val_date).as_buffer, sizeof(CK_DATE))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign date value.");
 			YYERROR;
 		    }
 		}
-#line 2180 "wrappedkey_parser.c"
+#line 2171 "wrappedkey_parser.c"
     break;
 
   case 102: /* pubkstmt: CKATTR_DATE ':' STRING  */
-#line 581 "wrappedkey_parser.y"
+#line 582 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, (yyvsp[-2].ckattr), (yyvsp[0].val_str).val, (yyvsp[0].val_str).len)!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign date value.");
@@ -2189,58 +2180,58 @@ yyreduce:
 		    }
 		    free((yyvsp[0].val_str).val);
 		}
-#line 2193 "wrappedkey_parser.c"
+#line 2184 "wrappedkey_parser.c"
     break;
 
   case 103: /* pubkstmt: CKATTR_KEY ':' KEYTYPE  */
-#line 590 "wrappedkey_parser.y"
+#line 591 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, (yyvsp[-2].ckattr), &(yyvsp[0].val_key), sizeof(CK_KEY_TYPE))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign key type value.");
 			YYERROR;
 		    }
 		}
-#line 2204 "wrappedkey_parser.c"
+#line 2195 "wrappedkey_parser.c"
     break;
 
   case 104: /* pubkstmt: CKATTR_CLASS ':' OCLASS  */
-#line 597 "wrappedkey_parser.y"
+#line 598 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, (yyvsp[-2].ckattr), &(yyvsp[0].val_cls), sizeof(CK_OBJECT_CLASS))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign object class value.");
 			YYERROR;
 		    }
 		}
-#line 2215 "wrappedkey_parser.c"
+#line 2206 "wrappedkey_parser.c"
     break;
 
   case 105: /* $@5: %empty  */
-#line 604 "wrappedkey_parser.y"
+#line 605 "wrappedkey_parser.y"
                 {
 		    if(ctx->pubkattribs->level==1) {
 			yyerror(ctx, "***Error: nesting templates not allowed");
 			YYERROR;
 		    }
-                    ctx->pubkattribs->level++; /*remind we are in a curly brace */
-		    
+		    ctx->pubkattribs->level++; /*remind we are in a curly brace */
+
 		    ctx->pubkattribs->current_idx = ctx->pubkattribs->saved_idx + 1; /*increment current idx from ctx->saved_idx */
 		    if(ctx->pubkattribs->current_idx>=4) {
 			/* There exist only 3 templates */
 			yyerror(ctx, "***Error: too many templates specified");
 			YYERROR;
-                   } 		    
+		   }
 		}
-#line 2234 "wrappedkey_parser.c"
+#line 2225 "wrappedkey_parser.c"
     break;
 
   case 106: /* pubkstmt: CKATTR_TEMPLATE ':' '{' $@5 pubkstmts '}'  */
-#line 619 "wrappedkey_parser.y"
+#line 620 "wrappedkey_parser.y"
                 {
 		    if(ctx->pubkattribs->level==0) {
-		        yyerror(ctx, "***Error: no matching opening curly brace");
+			yyerror(ctx, "***Error: no matching opening curly brace");
 			YYERROR;
-                    }
-                    ctx->pubkattribs->level--; /*out of curly brace now */
+		    }
+		    ctx->pubkattribs->level--; /*out of curly brace now */
 
 		    ctx->pubkattribs->saved_idx = ctx->pubkattribs->current_idx; /* remember which index we used last */
 		    ctx->pubkattribs->current_idx = ctx->pubkattribs->mainlist_idx; /* should be always 0 */
@@ -2248,39 +2239,39 @@ yyreduce:
 		    if(_wrappedkey_parser_pubk_assign_list_to_template(ctx, (yyvsp[-5].ckattr))!=rc_ok) {
 			yyerror(ctx, "Error during parsing, cannot assign attribute list to a template attribute.");
 			YYERROR;
-		    }		    
+		    }
 		}
-#line 2254 "wrappedkey_parser.c"
+#line 2245 "wrappedkey_parser.c"
     break;
 
   case 110: /* wrpjobstmt: P_WRAPPINGKEY '=' STRING  */
-#line 648 "wrappedkey_parser.y"
+#line 649 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_set_wrapping_key(ctx, (yyvsp[0].val_str).val, (yyvsp[0].val_str).len)!=rc_ok) {
-		        yyerror(ctx,"Parsing error with wrapping key identifier.");
+			yyerror(ctx,"Parsing error with wrapping key identifier.");
 			free((yyvsp[0].val_str).val);
-                        YYERROR;
-                    }
+			YYERROR;
+		    }
 		    free((yyvsp[0].val_str).val);
 		}
-#line 2267 "wrappedkey_parser.c"
+#line 2258 "wrappedkey_parser.c"
     break;
 
   case 111: /* wrpjobstmt: P_FILENAME '=' STRING  */
-#line 657 "wrappedkey_parser.y"
+#line 658 "wrappedkey_parser.y"
                 {
 		    if(_wrappedkey_parser_wkey_set_filename(ctx, (yyvsp[0].val_str).val)!=rc_ok) {
-		        yyerror(ctx,"Issue when saving filename");
+			yyerror(ctx,"Issue when saving filename");
 			free((yyvsp[0].val_str).val);
-                        YYERROR;
+			YYERROR;
 		    }
 		    free((yyvsp[0].val_str).val);
-                }
-#line 2280 "wrappedkey_parser.c"
+		}
+#line 2271 "wrappedkey_parser.c"
     break;
 
 
-#line 2284 "wrappedkey_parser.c"
+#line 2275 "wrappedkey_parser.c"
 
       default: break;
     }
@@ -2356,7 +2347,7 @@ yyerrlab:
           }
         yyerror (ctx, yymsgp);
         if (yysyntax_error_status == YYENOMEM)
-          goto yyexhaustedlab;
+          YYNOMEM;
       }
     }
 
@@ -2392,6 +2383,7 @@ yyerrorlab:
      label yyerrorlab therefore never appears in user code.  */
   if (0)
     YYERROR;
+  ++yynerrs;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -2452,7 +2444,7 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
 
 
 /*-----------------------------------.
@@ -2460,24 +2452,22 @@ yyacceptlab:
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
 
-#if 1
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (ctx, YY_("memory exhausted"));
   yyresult = 2;
-  goto yyreturn;
-#endif
+  goto yyreturnlab;
 
 
-/*-------------------------------------------------------.
-| yyreturn -- parsing is finished, clean up and return.  |
-`-------------------------------------------------------*/
-yyreturn:
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
   if (yychar != YYEMPTY)
     {
       /* Make sure we have latest lookahead translation.  See comments at
@@ -2505,5 +2495,5 @@ yyreturn:
   return yyresult;
 }
 
-#line 668 "wrappedkey_parser.y"
+#line 669 "wrappedkey_parser.y"
 

--- a/lib/wrappedkey_parser.h
+++ b/lib/wrappedkey_parser.h
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.7.6.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
@@ -45,7 +45,7 @@
 extern int yydebug;
 #endif
 /* "%code requires" blocks.  */
-#line 39 "wrappedkey_parser.y"
+#line 40 "wrappedkey_parser.y"
 
 
 #include "pkcs11lib.h"
@@ -114,7 +114,7 @@ extern int yylex(void);
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 52 "wrappedkey_parser.y"
+#line 53 "wrappedkey_parser.y"
 
     CK_ATTRIBUTE_TYPE ckattr;
     CK_KEY_TYPE val_key;
@@ -138,7 +138,7 @@ union YYSTYPE
 	    char month[2];
 	    char day[2];
 	} as_ck_date;
-        char as_buffer[8];
+	char as_buffer[8];
     } val_date;
 
     unsigned char *val_pem;	/* used to hold PEM-encoded blocks */
@@ -155,6 +155,8 @@ typedef union YYSTYPE YYSTYPE;
 
 extern YYSTYPE yylval;
 
+
 int yyparse (wrappedKeyCtx *ctx);
+
 
 #endif /* !YY_YY_WRAPPEDKEY_PARSER_H_INCLUDED  */

--- a/lib/wrappedkey_parser.y
+++ b/lib/wrappedkey_parser.y
@@ -24,6 +24,7 @@
 %expect 11
 
 %{
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -72,7 +73,7 @@ extern int yylex(void);
 	    char month[2];
 	    char day[2];
 	} as_ck_date;
-        char as_buffer[8];
+	char as_buffer[8];
     } val_date;
 
     unsigned char *val_pem;	/* used to hold PEM-encoded blocks */
@@ -103,7 +104,7 @@ extern int yylex(void);
 %token <val_date> TOK_DATE
 %token <val_key>  KEYTYPE
 %token <val_cls>  OCLASS
-%token <val_mech> CKMECH		
+%token <val_mech> CKMECH
 %token <val_dottednumber> DOTTEDNUMBER
 
 %token WRAPPINGJOBHEADER
@@ -141,9 +142,9 @@ innerblock:	INNER
 			yyerror(ctx,"Error when parsing encrypted key cryptogram (inner)");
 			YYERROR;
 		    }
-                    free($1);	/* free up mem */
+		    free($1);	/* free up mem */
 		}
-                ;
+		;
 
 outerblock:	OUTER
 		{
@@ -151,9 +152,9 @@ outerblock:	OUTER
 			yyerror(ctx,"Error when parsing encrypted key cryptogram (outer)");
 			YYERROR;
 		    }
-                    free($1);	/* free up mem */
+		    free($1);	/* free up mem */
 		}
-                ;
+		;
 
 wkeystmts:	wkeystmt
 	|	wkeystmts wkeystmt
@@ -184,11 +185,11 @@ metastmt:	CTYPE ':' CTYPE_VAL
 	|	WRAPPING_KEY ':' STRING /* for the time being, we capture just a key label */
 		{
 		    if(_wrappedkey_parser_wkey_set_wrapping_key(ctx, $3.val, $3.len)!=rc_ok) {
-		        yyerror(ctx,"Parsing error with wrapping key identifier.");
+			yyerror(ctx,"Parsing error with wrapping key identifier.");
 			free($3.val);
-                        YYERROR;
-                    }
-                    free($3.val);
+			YYERROR;
+		    }
+		    free($3.val);
 		}
 	;
 
@@ -197,14 +198,14 @@ assignstmts:	assignstmt
 	;
 
 assignstmt:	CKATTR_BOOL  ':' TOK_BOOLEAN
-                {
+		{
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, $1, &$3, sizeof(CK_BBOOL) )!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign boolean value.");
 			YYERROR;
 		    }
 		}
 	|	CKATTR_STR ':' STRING
-                {
+		{
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, $1, $3.val, $3.len)!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign bytes value.");
 			free($3.val);
@@ -213,14 +214,14 @@ assignstmt:	CKATTR_BOOL  ':' TOK_BOOLEAN
 		    free($3.val);
 		}
 	|	CKATTR_DATE ':' TOK_DATE
-                {
+		{
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, $1, $3.as_buffer, sizeof(CK_DATE))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign date value.");
 			YYERROR;
 		    }
 		}
 	|	CKATTR_DATE  ':' STRING /* if the date comes as 0x... format (not preferred but accepted) */
-                {
+		{
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, $1, $3.val, $3.len)!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign date value.");
 			free($3.val);
@@ -229,41 +230,41 @@ assignstmt:	CKATTR_BOOL  ':' TOK_BOOLEAN
 		    free($3.val);
 		}
 	|	CKATTR_KEY   ':' KEYTYPE
-                {
+		{
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, $1, &$3, sizeof(CK_KEY_TYPE))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign key type value.");
 			YYERROR;
 		    }
 		}
 	|	CKATTR_CLASS ':' OCLASS
-                {
+		{
 		    if(_wrappedkey_parser_wkey_append_attr(ctx, $1, &$3, sizeof(CK_OBJECT_CLASS))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign object class value.");
 			YYERROR;
 		    }
 		}
 	|	CKATTR_TEMPLATE ':' '{'
-	        {
+		{
 		    if(ctx->wrpkattribs->level==1) {
 			yyerror(ctx, "***Error: nesting templates not allowed");
 			YYERROR;
 		    }
-                    ctx->wrpkattribs->level++; /*remind we are in a curly brace */
-		    
+		    ctx->wrpkattribs->level++; /*remind we are in a curly brace */
+
 		    ctx->wrpkattribs->current_idx = ctx->wrpkattribs->saved_idx + 1; /*increment current idx from ctx->saved_idx */
 		    if(ctx->wrpkattribs->current_idx>=4) {
 			/* There exist only 3 templates */
 			yyerror(ctx, "***Error: too many templates specified");
 			YYERROR;
-                   } 		    
+		   }
 		}
 		assignstmts '}'
 		{
 		    if(ctx->wrpkattribs->level==0) {
-		        yyerror(ctx, "***Error: no matching opening curly brace");
+			yyerror(ctx, "***Error: no matching opening curly brace");
 			YYERROR;
-                    }
-                    ctx->wrpkattribs->level--; /*out of curly brace now */
+		    }
+		    ctx->wrpkattribs->level--; /*out of curly brace now */
 
 		    ctx->wrpkattribs->saved_idx = ctx->wrpkattribs->current_idx; /* remember which index we used last */
 		    ctx->wrpkattribs->current_idx = ctx->wrpkattribs->mainlist_idx; /* should be always 0 */
@@ -271,11 +272,11 @@ assignstmt:	CKATTR_BOOL  ':' TOK_BOOLEAN
 		    if(_wrappedkey_parser_wkey_assign_list_to_template(ctx, $1)!=rc_ok) {
 			yyerror(ctx, "Error during parsing, cannot assign attribute list to a template attribute.");
 			YYERROR;
-		    }		    
+		    }
 		}
 	|	CKATTR_ALLOWEDMECH ':' '{' mechanisms '}'
-      	        {
-	            if( _wrappedkey_parser_wkey_append_attr( ctx,
+		{
+		    if( _wrappedkey_parser_wkey_append_attr( ctx,
 							     $1,
 							     pkcs11_wctx_get_allowed_mechanisms(ctx),
 							     pkcs11_wctx_get_allowed_mechanisms_len(ctx))
@@ -283,7 +284,7 @@ assignstmt:	CKATTR_BOOL  ':' TOK_BOOLEAN
 			yyerror(ctx,"Error during parsing, cannot assign object class value.");
 			YYERROR;
 		    }
-		    /* pointer stolen, we must forget it */		
+		    /* pointer stolen, we must forget it */
 		    pkcs11_wctx_forget_mechanisms(ctx);
 		}
 		;
@@ -300,16 +301,16 @@ mechanism:	CKMECH
 		    }
 		}
 	;
-		
+
 
 /* we support these wrapping algorithms so far. */
 /* algorithms themselves are tokenized separately to allow parameter check against requested algorithm */
 algo:		pkcs1algo
 		| oaepalgo
 		| cbcpadalgo
-                | rfc3394algo
-                | rfc5649algo
-                | envelopealgo
+		| rfc3394algo
+		| rfc5649algo
+		| envelopealgo
 		;
 
 pkcs1algo:	pkcs1algoheader
@@ -375,10 +376,10 @@ oaepparam:	PARAMHASH '=' CKMECH
 		{
 		    if(_wrappedkey_parser_wkey_set_wrapping_param_label(ctx, $3.val, $3.len)!=rc_ok) {
 			yyerror(ctx,"Parsing error with specified wrapping algorithm.");
-                        free($3.val);
+			free($3.val);
 			YYERROR;
 		    }
-                    free($3.val);
+		    free($3.val);
 		}
 		;
 
@@ -413,12 +414,12 @@ cbcpadparam:	PARAMIV '=' STRING
 		{
 		    if(_wrappedkey_parser_wkey_set_wrapping_param_iv(ctx, $3.val, $3.len)!=rc_ok) {
 			yyerror(ctx,"Parsing error with specified wrapping algorithm.");
-                        free($3.val);
+			free($3.val);
 			YYERROR;
 		    }
-                    free($3.val);
+		    free($3.val);
 		}
-	        ;
+		;
 
 /* RFC3394: using CKM_AES_KEY_WRAP */
 
@@ -478,11 +479,11 @@ rfc5649param:   PARAMFLAVOUR '=' CKMECH
 			YYERROR;
 		    }
 		}
-	        ;
+		;
 /* envelope(): to support double wrapping */
 envelopealgo:	envelopealgoheader	/*take default parameters: all SHA1, label="" */
 	|	envelopealgoheader '('
-                {
+		{
 		    if(++parsing_envelope>1) {
 			yyerror(ctx, "Nested envelope() algorithm not allowed.");
 			YYERROR;
@@ -506,7 +507,7 @@ envelopealgoheader:	envelopealgoid
 /* TODO: check DOTTEDNUMBER to see if we agree with version     */
 /* there should be at least a warning if version is beyond supported one  */
 envelopealgoid:	ENVELOPEALGO
-             |	ENVELOPEALGO '/' DOTTEDNUMBER { free($3); }
+	     |	ENVELOPEALGO '/' DOTTEDNUMBER { free($3); }
 	     ;
 
 envelopeparamlist:	envelopeparam
@@ -523,15 +524,15 @@ envelopeparam:	PARAMOUTER '='
 		    envelope_keyindex = WRAPPEDKEYCTX_INNER_KEY_INDEX;
 		}
 		inneralgo
-        	;
-
-outeralgo:      pkcs1algo
-	|     	oaepalgo
 		;
 
-inneralgo: 	cbcpadalgo
+outeralgo:      pkcs1algo
+	|	oaepalgo
+		;
+
+inneralgo:	cbcpadalgo
 	|       rfc3394algo
-        |       rfc5649algo
+	|       rfc5649algo
 		;
 
 
@@ -545,24 +546,24 @@ pubkblock:	PUBK
 			yyerror(ctx,"Error when parsing public key information");
 			YYERROR;
 		    }
-                    free($1);	/* free up mem */
+		    free($1);	/* free up mem */
 		}
-                ;
+		;
 
-pubkstmts: 	pubkstmt
+pubkstmts:	pubkstmt
 	|	pubkstmts pubkstmt
 		;
 
 
 pubkstmt:	CKATTR_BOOL  ':' TOK_BOOLEAN
-                {
+		{
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, $1, &$3, sizeof(CK_BBOOL) )!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign boolean value.");
 			YYERROR;
 		    }
 		}
 	|	CKATTR_STR ':' STRING
-                {
+		{
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, $1, $3.val, $3.len)!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign bytes value.");
 			free($3.val);
@@ -571,14 +572,14 @@ pubkstmt:	CKATTR_BOOL  ':' TOK_BOOLEAN
 		    free($3.val);
 		}
 	|	CKATTR_DATE ':' TOK_DATE
-                {
+		{
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, $1, $3.as_buffer, sizeof(CK_DATE))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign date value.");
 			YYERROR;
 		    }
 		}
 	|	CKATTR_DATE  ':' STRING /* if the date comes as 0x... format (not preferred but accepted) */
-                {
+		{
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, $1, $3.val, $3.len)!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign date value.");
 			free($3.val);
@@ -587,41 +588,41 @@ pubkstmt:	CKATTR_BOOL  ':' TOK_BOOLEAN
 		    free($3.val);
 		}
 	|	CKATTR_KEY   ':' KEYTYPE
-                {
+		{
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, $1, &$3, sizeof(CK_KEY_TYPE))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign key type value.");
 			YYERROR;
 		    }
 		}
 	|	CKATTR_CLASS ':' OCLASS
-                {
+		{
 		    if(_wrappedkey_parser_pubk_append_attr(ctx, $1, &$3, sizeof(CK_OBJECT_CLASS))!=rc_ok) {
 			yyerror(ctx,"Error during parsing, cannot assign object class value.");
 			YYERROR;
 		    }
 		}
 	|	CKATTR_TEMPLATE ':' '{'
-	        {
+		{
 		    if(ctx->pubkattribs->level==1) {
 			yyerror(ctx, "***Error: nesting templates not allowed");
 			YYERROR;
 		    }
-                    ctx->pubkattribs->level++; /*remind we are in a curly brace */
-		    
+		    ctx->pubkattribs->level++; /*remind we are in a curly brace */
+
 		    ctx->pubkattribs->current_idx = ctx->pubkattribs->saved_idx + 1; /*increment current idx from ctx->saved_idx */
 		    if(ctx->pubkattribs->current_idx>=4) {
 			/* There exist only 3 templates */
 			yyerror(ctx, "***Error: too many templates specified");
 			YYERROR;
-                   } 		    
+		   }
 		}
 		pubkstmts '}'
 		{
 		    if(ctx->pubkattribs->level==0) {
-		        yyerror(ctx, "***Error: no matching opening curly brace");
+			yyerror(ctx, "***Error: no matching opening curly brace");
 			YYERROR;
-                    }
-                    ctx->pubkattribs->level--; /*out of curly brace now */
+		    }
+		    ctx->pubkattribs->level--; /*out of curly brace now */
 
 		    ctx->pubkattribs->saved_idx = ctx->pubkattribs->current_idx; /* remember which index we used last */
 		    ctx->pubkattribs->current_idx = ctx->pubkattribs->mainlist_idx; /* should be always 0 */
@@ -629,7 +630,7 @@ pubkstmt:	CKATTR_BOOL  ':' TOK_BOOLEAN
 		    if(_wrappedkey_parser_pubk_assign_list_to_template(ctx, $1)!=rc_ok) {
 			yyerror(ctx, "Error during parsing, cannot assign attribute list to a template attribute.");
 			YYERROR;
-		    }		    
+		    }
 		}
 		;
 
@@ -640,28 +641,28 @@ pubkstmt:	CKATTR_BOOL  ':' TOK_BOOLEAN
 wrappingjob:	WRAPPINGJOBHEADER wrpjobstmts
 		;
 
-wrpjobstmts: 	wrpjobstmt
+wrpjobstmts:	wrpjobstmt
 	|	wrpjobstmts ',' wrpjobstmt
 		;
 
 wrpjobstmt:	P_WRAPPINGKEY '=' STRING
 		{
 		    if(_wrappedkey_parser_wkey_set_wrapping_key(ctx, $3.val, $3.len)!=rc_ok) {
-		        yyerror(ctx,"Parsing error with wrapping key identifier.");
+			yyerror(ctx,"Parsing error with wrapping key identifier.");
 			free($3.val);
-                        YYERROR;
-                    }
+			YYERROR;
+		    }
 		    free($3.val);
 		}
 	|	P_FILENAME '=' STRING
 		{
 		    if(_wrappedkey_parser_wkey_set_filename(ctx, $3.val)!=rc_ok) {
-		        yyerror(ctx,"Issue when saving filename");
+			yyerror(ctx,"Issue when saving filename");
 			free($3.val);
-                        YYERROR;
+			YYERROR;
 		    }
 		    free($3.val);
-                }
+		}
 	|	P_ALGORITHM '=' algo
 	;
 


### PR DESCRIPTION
Fixes the compilation issue with GCC 11 and newer. 
Lexer and parser files must have `#include <config.h>` at the top of generated C files.
