### PR TITLE
fix: support for utimaco

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -178,6 +178,21 @@ AS_IF([test "x$with_awscloudhsm" != xno],
                fi
               ] )])
 
+dnl check if utimaco support can be compiled.
+dnl Note that utimaco is set to "no" instead of "check" by default, as the file is shipped with source code
+dnl and as enabling utimaco disable support for template attributes on p11ls and p11od.
+AC_ARG_WITH([utimaco],
+	[AS_HELP_STRING([--with-utimaco],
+	[enable support for the utimaco])],
+        [],
+        [with_utimaco=no])
+
+hasutimaco="no"
+AS_IF([test "x$with_utimaco" != xno],
+      [AC_DEFINE([HAVE_UTIMACO], [1], [define to compile with the utimaco support.])
+  hasutimaco="yes"
+      ])
+
 dnl check if a specific rpath is provided when linking.
 dnl this option is needed when openssl is not deployed to a system-wide location
 AC_ARG_VAR([LIBCRYPTO_RPATH], 	[provide RPATH to LIBCRYPTO, e.g. LIBCRYPTO_RPATH=/usr/local/ssl/lib (useful when openssl is not deployed to a system-wide location)])
@@ -219,6 +234,7 @@ AC_MSG_NOTICE([parser flags       : $YFLAGS])
 AC_MSG_NOTICE([with_luna          : $hasluna])
 AC_MSG_NOTICE([with_ncipher       : $hasncipher])
 AC_MSG_NOTICE([with_awscloudhsm   : $hasawscloudhsm])
+AC_MSG_NOTICE([with_utimaco       : $hasutimaco])
 AC_MSG_NOTICE([libcrypto rpath    : $LIBCRYPTO_RPATH])
 AC_MSG_NOTICE([------------------------------------------------------------------------])
 

--- a/lib/pkcs11_ls.c
+++ b/lib/pkcs11_ls.c
@@ -578,7 +578,7 @@ static int ls_seck(pkcs11Context *p11Context, CK_OBJECT_HANDLE hndl)
 				_ATTR(CKA_START_DATE),
 				_ATTR(CKA_END_DATE),
 				_ATTR(CKA_DERIVE),
-#if !defined(HAVE_AWSCLOUDHSM)	/* AWS CloudHSM cannot handle this */
+#if !defined(HAVE_AWSCLOUDHSM) && !defined(HAVE_UTIMACO)	/* AWS CloudHSM and Utimaco cannot handle this */
 				_ATTR(CKA_DERIVE_TEMPLATE),
 #endif
 				_ATTR(CKA_LOCAL),

--- a/lib/pkcs11_od.c
+++ b/lib/pkcs11_od.c
@@ -713,8 +713,10 @@ func_rc pkcs11_dump_object_with_label(pkcs11Context *p11Context, char *label)
 					    _ATTR(CKA_KEY_GEN_MECHANISM),
 
 					    _ATTR(CKA_MODIFIABLE),
+#if !defined(HAVE_UTIMACO)	/* Utimaco cannot handle this */
 					    _ATTR(CKA_COPYABLE),
 					    _ATTR(CKA_DESTROYABLE),
+#endif
 
 					    _ATTR(CKA_EC_PARAMS),
 
@@ -722,14 +724,17 @@ func_rc pkcs11_dump_object_with_label(pkcs11Context *p11Context, char *label)
 
 /* CKA_SECONDARY_AUTH, CKA_AUTH_PIN_FLAGS,
  * are new for v2.10. Deprecated in v2.11 and onwards. */
+#if !defined(HAVE_UTIMACO)	/* Utimaco cannot handle this */
 					    _ATTR(CKA_SECONDARY_AUTH),
 					    _ATTR(CKA_AUTH_PIN_FLAGS),
+#endif
 
 					    _ATTR(CKA_ALWAYS_AUTHENTICATE),
 
 					    _ATTR(CKA_WRAP_WITH_TRUSTED),
 					    _ATTR(CKA_WRAP_TEMPLATE),
 					    _ATTR(CKA_UNWRAP_TEMPLATE),
+#if !defined(HAVE_UTIMACO)	/* Utimaco cannot handle this */
 					    _ATTR(CKA_DERIVE_TEMPLATE),
 
 					    _ATTR(CKA_OTP_FORMAT),
@@ -750,8 +755,10 @@ func_rc pkcs11_dump_object_with_label(pkcs11Context *p11Context, char *label)
 					    _ATTR(CKA_GOSTR3410_PARAMS),
 					    _ATTR(CKA_GOSTR3411_PARAMS),
 					    _ATTR(CKA_GOST28147_PARAMS),
+#endif
 
 					    _ATTR(CKA_HW_FEATURE_TYPE),
+#if !defined(HAVE_UTIMACO)	/* Utimaco cannot handle this */
 					    _ATTR(CKA_RESET_ON_INIT),
 					    _ATTR(CKA_HAS_RESET),
 
@@ -769,6 +776,7 @@ func_rc pkcs11_dump_object_with_label(pkcs11Context *p11Context, char *label)
 					    _ATTR(CKA_REQUIRED_CMS_ATTRIBUTES),
 					    _ATTR(CKA_DEFAULT_CMS_ATTRIBUTES),
 					    _ATTR(CKA_SUPPORTED_CMS_ATTRIBUTES),
+#endif
 					    _ATTR(CKA_ALLOWED_MECHANISMS),
 
 #if defined(HAVE_NCIPHER)

--- a/src/version.c
+++ b/src/version.c
@@ -40,5 +40,8 @@ void print_version_info(char *progname)
 #if defined(HAVE_AWSCLOUDHSM)
     fprintf( stderr, "compiled with AWS CloudHSM extensions\n");
 #endif
+#if defined(HAVE_UTIMACO)
+    fprintf( stderr, "compiled with Utimaco support\n");
+#endif
     exit( RC_ERROR_USAGE );
 }


### PR DESCRIPTION
When using p11ls & p11od with Utimaco HSM, there are lots of attribute types that Utimaco doesn't support.
```
PKCS11LIB=* CS_PKCS11_R2_CFG=* PKCS11SLOT=* PKCS11PASSWORD=* p11ls
Attribute 0x40000213 not found.
Error CKR_ATTRIBUTE_TYPE_INVALID occurred.
Attribute 0x40000213 not found.
Error CKR_ATTRIBUTE_TYPE_INVALID occurred.
Attribute 0x40000213 not found.
Error CKR_ATTRIBUTE_TYPE_INVALID occurred.
```
```
PKCS11LIB=* CS_PKCS11_R2_CFG=* PKCS11SLOT=* PKCS11PASSWORD=* p11od
Attribute 0x00000171 not found.
Error CKR_ATTRIBUTE_TYPE_INVALID occurred.
Attribute 0x00000171 not found.
Error CKR_ATTRIBUTE_TYPE_INVALID occurred.
Attribute 0x00000171 not found.
Error CKR_ATTRIBUTE_TYPE_INVALID occurred.
```
I found out all the attributes, and exclude them with the '--with-utimaco' flag