### PR TITLE
memleak fix: X509 and X509_REQ structures not disposed off properly

### DIFF
--- a/include/pkcs11lib.h
+++ b/include/pkcs11lib.h
@@ -586,6 +586,7 @@ CK_VOID_PTR pkcs11_create_X509_REQ(pkcs11Context *p11Context,
 				   pkcs11AttrList *attrlist) ;
 
 void write_X509_REQ(CK_VOID_PTR req, char *filename, bool verbose);
+void pkcs11_free_X509_REQ(CK_VOID_PTR req);
 
 /* pkcs11_cert.c */
 CK_VOID_PTR pkcs11_create_X509_CERT(pkcs11Context *p11Context,
@@ -600,7 +601,8 @@ CK_VOID_PTR pkcs11_create_X509_CERT(pkcs11Context *p11Context,
 				    CK_OBJECT_HANDLE hprivkey,
 				    pkcs11AttrList *attrlist);
 
-void write_X509_CERT(CK_VOID_PTR req, char *filename, bool verbose);
+void write_X509_CERT(CK_VOID_PTR crt, char *filename, bool verbose);
+void pkcs11_free_X509_CERT(CK_VOID_PTR crt);
 
 
 // CK_ULONG pkcs11_allocate_and_hash_sha1(CK_BYTE_PTR data, CK_ULONG datalen, CK_VOID_PTR_PTR buf);

--- a/lib/pkcs11_cert.c
+++ b/lib/pkcs11_cert.c
@@ -282,6 +282,15 @@ err:
 }
 
 
+void pkcs11_free_X509_CERT(CK_VOID_PTR crt) {
+    X509 *xcrt = (X509 *)crt;
+
+    if(xcrt) {
+	X509_free(xcrt);
+    }	
+}
+
+
 void write_X509_CERT(CK_VOID_PTR crt, char *filename, bool verbose)
 {
 

--- a/lib/pkcs11_req.c
+++ b/lib/pkcs11_req.c
@@ -249,6 +249,16 @@ err:
     return retval;
 }
 
+
+void pkcs11_free_X509_REQ(CK_VOID_PTR req) {
+    X509_REQ *xreq = (X509_REQ *)req;
+
+    if(xreq) {
+	X509_REQ_free(xreq);
+    }	
+}
+
+
 void write_X509_REQ(CK_VOID_PTR req, char *filename, bool verbose)
 {
 

--- a/src/p11mkcert.c
+++ b/src/p11mkcert.c
@@ -409,6 +409,7 @@ int main( int argc, char ** argv )
 			fprintf(stderr, "importing certificate succeeded.\n");
 		    }
 		}
+		pkcs11_free_X509_CERT(x509); /* free cert structure */
 	    } else {
 		fprintf(stderr, "Error: Unable to generate certificate\n");
 	    }

--- a/src/p11req.c
+++ b/src/p11req.c
@@ -368,6 +368,7 @@ int main( int argc, char ** argv )
 
 	    if(req) {
 		write_X509_REQ(req, filename, verbose);
+		pkcs11_free_X509_REQ(req);
 	    } else {
 		fprintf(stderr, "Error: Unable to generate certificate request\n");
 	    }


### PR DESCRIPTION
This PR comes to address issue #52. 
