### PR TITLE
fixing issue with comparison on some platforms (MIPS)

### DIFF
--- a/lib/pkcs11_mechanism.c
+++ b/lib/pkcs11_mechanism.c
@@ -58,7 +58,14 @@ static int compare_CKM_type( const void *a, const void *b)
     /* we need to use an intermediary value and divide it by itself (as absolute value)     */
 
     /* we explicitely use "signed" as some platform (MIPS) seem to work with unsigned by default */
-    signed long long item = (signed long long)(((MechanismDesc *)a)->type) - (signed long long)(((MechanismDesc *)b)->type);
+    //avoiding undefined behaviour
+    MechanismDesc* mech_a = (MechanismDesc*)a;
+    MechanismDesc* mech_b = (MechanismDesc*)b;
+    if(!mech_a || !mech_b) {
+        fprintf(stderr, "***Error: failed to detect valid mechanism description...exiting.\n");
+        exit(rc_error_invalid_argument);
+    }
+    signed long long item = (signed long long)(mech_a->type) - (signed long long)(mech_b->type);
     return item ? item/llabs(item) : 0;
 }
 

--- a/lib/pkcs11_mechanism.c
+++ b/lib/pkcs11_mechanism.c
@@ -56,9 +56,9 @@ static int compare_CKM_type( const void *a, const void *b)
 {
     /* because we are making a comparison between unsigned long, int might not reflect well */
     /* we need to use an intermediary value and divide it by itself (as absolute value)     */
-    
-    long long item = ((MechanismDesc *)a)->type - ((MechanismDesc *)b)->type;
 
+    /* we explicitely use "signed" as some platform (MIPS) seem to work with unsigned by default */
+    signed long long item = (signed long long)(((MechanismDesc *)a)->type) - (signed long long)(((MechanismDesc *)b)->type);
     return item ? item/llabs(item) : 0;
 }
 


### PR DESCRIPTION
Fix for issue #54: fixing issue with comparison on some platforms (MIPS), as unsigned arithmetic seems to be the default.
