### PR TITLE
Implement more options, for `p11kcv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [UNPUBLISHED]
 ### Added
+- `p11kcv` beefed up, to support multiple MACing algorithms, as well as displaying the value of `CKA_CHECK_VALUE`
 - support for wrapping keys in JOSE Web Key format (JWK, RFC 7178)
 - new option `--enable-duplicate`, to override duplicate label protection when creating or importing a key (must be enabled at compile time)
 - search templates: it is now possible to add other attributes in a search, to filter out on more than one attribute

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -60,7 +60,7 @@ else
 fi
 
 # invoke gnulib
-.gnulib/gnulib-tool --import --dir=. --lib=libgnu --source-base=gl --m4-base=m4 --doc-base=doc --tests-base=tests --aux-dir=. --no-conditional-dependencies --no-libtool --macro-prefix=gl byteswap gethostname getline getopt-gnu malloc-gnu calloc-gnu realloc-gnu regex strcase strsep termios time sysexits
+.gnulib/gnulib-tool --import --dir=. --lib=libgnu --source-base=gl --m4-base=m4 --doc-base=doc --tests-base=tests --aux-dir=. --no-conditional-dependencies --no-libtool --macro-prefix=gl byteswap gethostname getline getopt-gnu malloc-gnu calloc-gnu realloc-gnu regex strcase strsep termios time sysexits minmax
 
 # create configure scripts
 autoreconf -vfi

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -836,17 +836,32 @@ To prevent this (some PKCS\#11 library do not support this), add the `-r` option
 ## p11kcv
 
 Computes the key check value of a symmetric key and prints it. This will work only on secret keys, i.e. DES, AES and
-HMAC keys.
+HMAC keys. Keys must have `CKA_SIGN` enabled, except for the 'ecb' method, where `CKA_ENCRYPT` must be enabled.
 
 The key check value is computed as follows:
 
-- For DES keys, it performs a signature (MACing) or an encryption on a block of 8 zeroised bytes, and outputs the
-  first 3 bytes.
-- For AES keys, it performs a signature (MACing) or an encryption on a block of 16 zeroised bytes, and outputs the
-  first 3 bytes.
+- For all keys:
+  - kcv: if `CKA_CHECK_VALUE` attribute is present on the key, and `kcv` is specified as the algorithm, the key check value is retrieved from the attribute value.
+  
+- For DES keys:
+  - legacy: signature or encryption on a block of 8 zeroized bytes, using ECB mode
+  - mac: FIPS PUB 113 MAC computation on a block of 8 zeroized bytes
+  
+- In addition, for 3DES keys:
+  - cmac: RFC4493 CMAC computation on a block of 16 zeroized bytes
+   
+- For AES keys:
+  - legacy: signature or encryption on a block of 16 zeroized bytes, using ECB mode
+  - cmac: RFC4493 CMAC computation on a block of 16 zeroized bytes
+  - aes-xcbc-mac: RFC3566 XCBC-MAC computation on a block of 16 zeroized bytes
+  - aes-xcbc-mac-16: RFC3566 XCBC-MAC-16 computation on a block of 16 zeroized bytes
+
 - For HMAC keys, the key check value is computed by HMACing a null-length buffer. Alternatively, it is possible to
   specify a length, using the `-b` optional argument, in which case a zeroised buffer of the specified length is used as
   input to the HMAC.
+
+The KCV algorithm can be set using the `-f` optional argument.
+By default, 3 bytes are printed, but this value can be adjusted using the `-n` optional argument.
 
 ## p11req
 

--- a/include/pkcs11lib.h
+++ b/include/pkcs11lib.h
@@ -223,7 +223,6 @@ typedef enum {
     sha512
 } hash_alg_t ;
 
-    
 /* attribCtx contains a context that can hold parameters parsed from command line
    that contains attributes.
    It currently supports these grammars:

--- a/include/pkcs11lib.h
+++ b/include/pkcs11lib.h
@@ -223,6 +223,7 @@ typedef enum {
     sha512
 } hash_alg_t ;
 
+    
 /* attribCtx contains a context that can hold parameters parsed from command line
    that contains attributes.
    It currently supports these grammars:
@@ -749,8 +750,24 @@ func_rc pkcs11_info_ecsupport(pkcs11Context *p11Context);
 func_rc pkcs11_change_object_attributes(pkcs11Context *p11Context, char *label, CK_ATTRIBUTE *attr, size_t cnt, int interactive );
 
 /* kcv functions */
+
+/* supported MAC algorithms, for p11kcv */
+typedef enum {
+    legacy,			/* legacy is used to behave like before: it picks the old algorithm, based upon the key type */
+    kcv,            /* tries to use CKA_CHECK_VALUE attribute if found */
+    hash_sha1,
+    hash_sha256,
+    hash_sha384,
+    hash_sha512,
+    ecb,			/* CKM_XXX_ECB method - can be used with an encryption key instead */
+    mac,			/* CKM_XXX_MAC */
+    cmac,			/* CKM_XXX_CMAC */
+    aes_xcbc_mac,		/* CKM_AES_XCBC_MAC */
+    aes_xcbc_mac_96,		/* CKM_AES_XCBC_MAC_96 */
+} mac_alg_t;
+
 #define MAX_KCV_CLEARTEXT_SIZE 256
-void pkcs11_display_kcv( pkcs11Context *p11Context, char *label, unsigned hmacdatasize );
+void pkcs11_display_kcv( pkcs11Context *p11Context, char *label, unsigned hmacdatasize, mac_alg_t algo, size_t kcvsize);
 
 /* wrap/unwrap functions */
 func_rc pkcs11_prepare_wrappingctx(wrappedKeyCtx *wctx, char *wrappingjob);

--- a/lib/pkcs11_kcv.c
+++ b/lib/pkcs11_kcv.c
@@ -32,7 +32,6 @@
 #define LABEL_WIDTH 32
 #endif
 
-
 /* target must point to a location with at least 3 bytes left */
 
 void pkcs11_display_kcv( pkcs11Context *p11Context, char *label, unsigned hmacdatasize, mac_alg_t algo, size_t num_bytes)

--- a/lib/pkcs11_kcv.c
+++ b/lib/pkcs11_kcv.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "minmax.h"
 
 #include <openssl/bio.h>
 #include <openssl/pem.h>
@@ -31,9 +32,10 @@
 #define LABEL_WIDTH 32
 #endif
 
+
 /* target must point to a location with at least 3 bytes left */
 
-void pkcs11_display_kcv( pkcs11Context *p11Context, char *label, unsigned hmacdatasize )
+void pkcs11_display_kcv( pkcs11Context *p11Context, char *label, unsigned hmacdatasize, mac_alg_t algo, size_t num_bytes)
 {
 
     pkcs11Search *search=NULL;
@@ -90,6 +92,9 @@ void pkcs11_display_kcv( pkcs11Context *p11Context, char *label, unsigned hmacda
 					    _ATTR(CKA_KEY_TYPE),
 					    _ATTR(CKA_ID),
 					    _ATTR(CKA_LABEL),
+						_ATTR(CKA_CHECK_VALUE),
+						_ATTR(CKA_SIGN),
+						_ATTR(CKA_ENCRYPT),
 					    _ATTR_END);
 
 		if( attrs!=NULL) {
@@ -100,9 +105,20 @@ void pkcs11_display_kcv( pkcs11Context *p11Context, char *label, unsigned hmacda
 			CK_ULONG cleartext_len, processed_len;
 
 			CK_MECHANISM des_ecb = { CKM_DES_ECB, NULL_PTR, 0 };
+			CK_MECHANISM des_mac = { CKM_DES_MAC, NULL_PTR, 0 };
+
 			CK_MECHANISM des3_ecb = { CKM_DES3_ECB, NULL_PTR, 0 };
+			CK_MECHANISM des3_mac = { CKM_DES3_MAC, NULL_PTR, 0 };
+			CK_MECHANISM des3_cmac = { CKM_DES3_CMAC, NULL_PTR, 0 };
+
 			CK_MECHANISM aes_ecb = { CKM_AES_ECB, NULL_PTR, 0 };
+			CK_MECHANISM aes_mac = { CKM_AES_MAC, NULL_PTR, 0 };
+			CK_MECHANISM aes_cmac = { CKM_AES_CMAC, NULL_PTR, 0 };
+			CK_MECHANISM m_aes_xcbc_mac = { CKM_AES_XCBC_MAC, NULL_PTR, 0};
+			CK_MECHANISM m_aes_xcbc_mac_96 = { CKM_AES_XCBC_MAC_96, NULL_PTR, 0};			
+
 			CK_MECHANISM sha1_hmac = { CKM_SHA_1_HMAC, NULL_PTR, 0 };
+			CK_MECHANISM sha224_hmac = { CKM_SHA224_HMAC, NULL_PTR, 0 };
 			CK_MECHANISM sha256_hmac = { CKM_SHA256_HMAC, NULL_PTR, 0 };
 			CK_MECHANISM sha384_hmac = { CKM_SHA384_HMAC, NULL_PTR, 0 };
 			CK_MECHANISM sha512_hmac = { CKM_SHA512_HMAC, NULL_PTR, 0 };
@@ -112,148 +128,261 @@ void pkcs11_display_kcv( pkcs11Context *p11Context, char *label, unsigned hmacda
 
 			CK_MECHANISM_PTR mechanism = NULL ;
 
-			CK_ATTRIBUTE_PTR keytype = pkcs11_get_attr_in_attrlist ( attrs, CKA_KEY_TYPE );
-			CK_ATTRIBUTE_PTR label   = pkcs11_get_attr_in_attrlist ( attrs, CKA_LABEL );
-			CK_ATTRIBUTE_PTR id      = pkcs11_get_attr_in_attrlist ( attrs, CKA_ID );
+			CK_ATTRIBUTE_PTR a_keytype = pkcs11_get_attr_in_attrlist ( attrs, CKA_KEY_TYPE );
+			CK_ATTRIBUTE_PTR a_label   = pkcs11_get_attr_in_attrlist ( attrs, CKA_LABEL );
+			CK_ATTRIBUTE_PTR a_id      = pkcs11_get_attr_in_attrlist ( attrs, CKA_ID );
+			CK_ATTRIBUTE_PTR a_check_value = pkcs11_get_attr_in_attrlist ( attrs, CKA_CHECK_VALUE );
+			CK_ATTRIBUTE_PTR a_sign = pkcs11_get_attr_in_attrlist ( attrs, CKA_SIGN );
+			CK_ATTRIBUTE_PTR a_encrypt = pkcs11_get_attr_in_attrlist ( attrs, CKA_ENCRYPT );
+
+			bool can_sign = a_sign && a_sign->pValue && *((CK_BBOOL *)a_sign->pValue) == CK_TRUE;
+			bool can_encrypt = a_encrypt && a_encrypt->pValue && *((CK_BBOOL *)a_encrypt->pValue) == CK_TRUE;
+			bool has_check_value = a_check_value && a_check_value->pValue;
 
 			char buffer[81];
 			int buffer_len = sizeof buffer;
 			char *keytypestr = NULL;
+			int max_num_bytes = 0;
 
 			memset(cleartext,0x00,sizeof cleartext);
 
-			label_or_id(label, id, buffer, buffer_len); /* first thing: retrieve label or id */
+			label_or_id(a_label, a_id, buffer, buffer_len); /* first thing: retrieve a_label or id */
 
-			if(keytype==NULL) {
+			if(a_keytype==NULL) {
 			    fprintf(stderr, "Found no CKA_KEY_TYPE for object %s, skipping\n", buffer);
 			    pkcs11_delete_attrlist(attrs);
 			    continue;
 			}
 
-			switch( *((CK_KEY_TYPE *)keytype->pValue)) {
-			case CKK_DES:
-			    mechanism = &des_ecb;
-			    cleartext_len = 8L;
-			    processed_len = 8L;
-			    keytypestr = "DES, single length";
-			    whattodo=encrypt;
-			    break;
+			bool is_des2 = false;
+			
+			/* if we ask for KCV  explicitely */
+			if(has_check_value && algo == kcv) {
+				// if we have a check value, we just display it
+				max_num_bytes = num_bytes = processed_len = MIN(a_check_value->ulValueLen, sizeof(processed));
+				keytypestr = "CKA_CHECK_VALUE";
+				memcpy(processed, a_check_value->pValue, processed_len);
+			} else {
+				switch( *((CK_KEY_TYPE *)a_keytype->pValue)) {
+				case CKK_DES:
+					cleartext_len = 8L;
+					processed_len = 8L;
+					max_num_bytes = 8;
+					
+					switch(algo) {
+					case legacy:
+					mechanism = &des_ecb;
+					whattodo=encrypt;
+					keytypestr = "DES, single length, ECB";
+					break;
 
-			case CKK_DES2:
-			    mechanism = &des3_ecb;
-			    cleartext_len = 8L;
-			    processed_len = 8L;
-			    keytypestr = "3DES, double length";
-			    whattodo=encrypt;
-			    break;
+					case mac:
+					mechanism = &des_mac;
+					whattodo=sign;
+					keytypestr = "DES, single length, MAC/FIPS PUB 113";
+					break;
 
-			case CKK_DES3:
-			    mechanism = &des3_ecb;
-			    cleartext_len = 8L;
-			    processed_len = 8L;
-			    keytypestr = "3DES, triple length";
-			    whattodo=encrypt;
-			    break;
+					default:
+					/* unsupported, we just break, no mechanism defined */
+					}
+					break;
 
-			case CKK_AES:
-			    mechanism = &aes_ecb;
-			    cleartext_len = 16L;
-			    processed_len = 16L;
-			    keytypestr = "AES";
-			    whattodo=encrypt;
-			    break;
+				case CKK_DES2:
+					is_des2 = true;
+					/* no break here */
+					
+				case CKK_DES3:
+					cleartext_len = 8L;
+					processed_len = 8L;
 
-			case CKK_SHA_1_HMAC:
-			    mechanism = &sha1_hmac;
-			    cleartext_len = hmacdatasize;
-			    processed_len = 20L;
-			    keytypestr = "HMAC(SHA1)";
-			    whattodo=sign;
-			    break;
+					switch(algo) {
+					case legacy:
+					mechanism = &des3_ecb;
+					whattodo=encrypt;
+					max_num_bytes = 8;
+					keytypestr = is_des2 ? "3DES, double length, ECB" : "3DES, triple length, ECB";
+					break;
 
-			case CKK_SHA256_HMAC:
-			case CKK_GENERIC_SECRET:
-			    mechanism = &sha256_hmac;
-			    cleartext_len = hmacdatasize;
-			    processed_len = 32L;
-			    keytypestr = "HMAC(SHA256)";
-			    whattodo=sign;
-			    break;
+					case mac:
+					mechanism = &des3_mac;
+					whattodo=sign;
+					max_num_bytes = 8;
+					keytypestr = is_des2 ? "3DES, double length, MAC/FIPS PUB 113" : "3DES, triple length, MAC/FIPS PUB 113";
+					break;
 
-			case CKK_SHA384_HMAC:
-			    mechanism = &sha384_hmac;
-			    cleartext_len = hmacdatasize;
-			    processed_len = 48L;
-			    keytypestr = "HMAC(SHA384)";
-			    whattodo=sign;
-			    break;
+					case cmac:
+					mechanism = &des3_cmac;
+					whattodo=sign;
+					max_num_bytes = 4;
+					keytypestr = is_des2 ? "3DES, double length, CMAC/RFC4493" : "3DES, triple length, CMAC/RFC4493";
+					break;
 
-			case CKK_SHA512_HMAC:
-			    mechanism = &sha512_hmac;
-			    cleartext_len = hmacdatasize;
-			    processed_len = 64L;
-			    keytypestr = "HMAC(SHA384)";
-			    whattodo=sign;
-			    break;
+					default:
+					/* unsupported, we just break, no mechanism defined */
+					}			    
+					break;
 
-			default:
-			    break;
+
+				case CKK_AES:
+					cleartext_len = 16L;
+					processed_len = 16L;
+
+					switch(algo) {
+					case legacy:
+					mechanism = &aes_ecb;
+					whattodo=encrypt;
+					max_num_bytes = 16;
+					keytypestr = "AES, ECB";
+					break;
+
+					case mac:
+					mechanism = &aes_mac;
+					whattodo=sign;
+					max_num_bytes = 16;
+					keytypestr = "AES, MAC/FIPS PUB 113";
+					break;
+
+					case cmac:
+					mechanism = &aes_cmac;
+					whattodo=sign;
+					max_num_bytes = 8;
+					keytypestr = "AES, CMAC/RFC4493";
+					break;
+
+					case aes_xcbc_mac:
+					mechanism = &m_aes_xcbc_mac;
+					whattodo=sign;
+					max_num_bytes = 16;
+					keytypestr = "AES, XCBC-MAC/RFC3566";
+					break;
+
+					case aes_xcbc_mac_96:
+					mechanism = &m_aes_xcbc_mac_96;
+					whattodo=sign;
+					max_num_bytes = 12;
+					keytypestr = "AES, XCBC-MAC-96/RFC3566";
+					break;
+
+					default:
+					/* unsupported, we just break, no mechanism defined */
+					}			    
+					break;
+
+				case CKK_SHA_1_HMAC:
+					mechanism = &sha1_hmac;
+					cleartext_len = hmacdatasize;
+					processed_len = 20L;
+					keytypestr = "HMAC/SHA1";
+					whattodo=sign;
+					max_num_bytes = 20;
+					break;
+
+				case CKK_SHA224_HMAC:
+					mechanism = &sha224_hmac;
+					cleartext_len = hmacdatasize;
+					processed_len = 28L;
+					keytypestr = "HMAC/SHA244";
+					whattodo=sign;
+					max_num_bytes = 28;
+					break;
+
+				case CKK_SHA256_HMAC:
+				case CKK_GENERIC_SECRET:
+					mechanism = &sha256_hmac;
+					cleartext_len = hmacdatasize;
+					processed_len = 32L;
+					keytypestr = "HMAC/SHA256";
+					whattodo=sign;
+					max_num_bytes = 32;
+					break;
+
+				case CKK_SHA384_HMAC:
+					mechanism = &sha384_hmac;
+					cleartext_len = hmacdatasize;
+					processed_len = 48L;
+					keytypestr = "HMAC/SHA384";
+					whattodo=sign;
+					max_num_bytes = 48;
+					break;
+
+				case CKK_SHA512_HMAC:
+					mechanism = &sha512_hmac;
+					cleartext_len = hmacdatasize;
+					processed_len = 64L;
+					keytypestr = "HMAC/SHA512";
+					whattodo=sign;
+					max_num_bytes = 64;
+					break;
+
+				default:
+					break;
+				}
+
+				if(mechanism==NULL) {
+					fprintf(stderr, "Unsupported mechanism for key %s, skipping\n", buffer);
+					pkcs11_delete_attrlist(attrs);
+					continue;
+				}
+
+				if(!can_sign && whattodo==sign) {
+					fprintf(stderr, "Key %s cannot sign, skipping\n", buffer);
+					pkcs11_delete_attrlist(attrs);
+					continue;
+				}
+
+				if(!can_encrypt && whattodo==encrypt) {
+					fprintf(stderr, "Key %s cannot encrypt, skipping\n", buffer);
+					pkcs11_delete_attrlist(attrs);
+					continue;
+				}
+
+				rv = whattodo == encrypt ?
+					p11Context->FunctionList.C_EncryptInit( p11Context->Session,
+										mechanism,
+										hndl_array[j]) :
+					p11Context->FunctionList.C_SignInit( p11Context->Session,
+									mechanism,
+									hndl_array[j]);
+
+				if(rv!=CKR_OK) {
+					pkcs11_error(rv, whattodo == encrypt ? "C_EncryptInit" : "C_SignInit");
+					pkcs11_delete_attrlist(attrs);
+					continue;
+				}
+
+				rv = whattodo == encrypt ?
+					p11Context->FunctionList.C_Encrypt ( p11Context->Session,
+									cleartext,
+									cleartext_len,
+									processed,
+									&processed_len	) :
+					p11Context->FunctionList.C_Sign ( p11Context->Session,
+									cleartext,
+									cleartext_len,
+									processed,
+									&processed_len );
+				if(rv!=CKR_OK) {
+					pkcs11_error(rv, whattodo == encrypt ? "C_Encrypt" : "C_Sign");
+					pkcs11_delete_attrlist(attrs);
+					continue;
+				}
 			}
-
-			if(mechanism==NULL) {
-			    fprintf(stderr, "Unsupported mechanism for key %s, skipping\n", buffer);
-			    pkcs11_delete_attrlist(attrs);
-			    continue;
-			}
-
-			rv = whattodo == encrypt ?
-			    p11Context->FunctionList.C_EncryptInit( p11Context->Session,
-								    mechanism,
-								    hndl_array[j]) :
-			    p11Context->FunctionList.C_SignInit( p11Context->Session,
-								 mechanism,
-								 hndl_array[j]);
-
-			if(rv!=CKR_OK) {
-			    pkcs11_error(rv, whattodo == encrypt ? "C_EncryptInit" : "C_SignInit");
-			    pkcs11_delete_attrlist(attrs);
-			    continue;
-			}
-
-			rv = whattodo == encrypt ?
-			    p11Context->FunctionList.C_Encrypt ( p11Context->Session,
-								 cleartext,
-								 cleartext_len,
-								 processed,
-								 &processed_len	) :
-			    p11Context->FunctionList.C_Sign ( p11Context->Session,
-							      cleartext,
-							      cleartext_len,
-							      processed,
-							      &processed_len );
-			if(rv!=CKR_OK) {
-			    pkcs11_error(rv, whattodo == encrypt ? "C_Encrypt" : "C_Sign");
-			    pkcs11_delete_attrlist(attrs);
-			    continue;
-			}
-
+			
 			/* now, the display job */
-			printf("%-*s: KCV = %2.2x%2.2x%2.2x (%s)\n",
-			       LABEL_WIDTH,
-			       buffer,
-			       processed[0],
-			       processed[1],
-			       processed[2],
-			       keytypestr);
+			printf("%-*s: KCV = ", LABEL_WIDTH, buffer);
+			for (int k = 0; k < MIN(num_bytes, max_num_bytes); k++) {
+			    printf("%2.2x", processed[k]);
+			}
+			printf(" (%s)\n", keytypestr);
+			pkcs11_delete_attrlist(attrs);
 		    }
-		    pkcs11_delete_attrlist(attrs);
 		}
 	    }
 	}
-    }
-error:
-    if(hndl_array) free(hndl_array);
-    if(search) pkcs11_delete_search(search);
-    if(idtmpl) pkcs11_delete_idtemplate(idtmpl);
+    error:
+	if(hndl_array) free(hndl_array);
+	if(search) pkcs11_delete_search(search);
+	if(idtmpl) pkcs11_delete_idtemplate(idtmpl);
 
+    }
 }


### PR DESCRIPTION
This PR brings the following features:
- `CKA_CHECK_VALUE` can be used (when present)
- support for CMAC
- support for XCBC-MAC and XBCB-MAC-96
- support for legacy (FIPS PUB 113) MAC on 3DES keys
- attributes (signing and encryption) are checked before respective functions are invoked
- documentation changes.

This PR should address the requests from issue #59.
