### PR TITLE
Implement building the project using `docker buildx`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 
 ## development tools
 .gdb_history
-.python_version
+.python-version
 *.patch
 .idea
 
@@ -61,6 +61,11 @@ Makefile.in
 *~
 /TAGS
 
+# Linux distro files
+*.rpm
+*.deb
+*.apk
+
 # key files
 *.pubk
 *.prvk
@@ -70,4 +75,8 @@ Makefile.in
 
 # pkcs11 wrapper script files
 .pkcs11rc
+
+# VSCode
+.vscode/
+.clang-format
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [UNPUBLISHED]
 ### Added
+- support for Docker builds
 - `p11req` and `p11mkcert` now support RSA-PSS signature (add `-a pss` arguments to select it)
 - `p11kcv` beefed up, to support multiple MACing algorithms, as well as displaying the value of `CKA_CHECK_VALUE`
 - support for wrapping keys in JOSE Web Key format (JWK, RFC 7178)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,10 +33,19 @@ trap cleanup EXIT
 oldpath=$PWD
 cd ${oldpath}
 
+# we allow one optional argument to this script,
+# which is --shallow-clone to indicate that we want to
+# perform a shallow clone of the gnulib submodule (limit depth to 1)
+SHALLOW_CLONE=""
+if [ "$1" = "--shallow-clone" ]; then
+    echo "Performing a shallow clone of submodules"
+    SHALLOW_CLONE="--depth 1"
+fi
+
 # detect if we are in a git repo
 if [ -d .git ]; then
     # pull submodule stuff
-    git submodule update --init
+    git submodule update --init ${SHALLOW_CLONE}
     #    git submodule update --init .gnulib
     #    git submodule update --init include/oasis-pkcs11
 

--- a/buildx.sh
+++ b/buildx.sh
@@ -26,7 +26,7 @@ PACKAGE="pkcs11-tools"
 GITHUB_REPO="https://github.com/Mastercard/pkcs11-tools"
 GITHUB_REPO_COMMIT="HEAD"
 SUPPORTED_ARCHS="amd64 arm64"
-SUPPORTED_DISTROS="ol7 ol8 ol9 deb12 ubuntu2204 ubuntu2404 amzn2023 alpine321"
+SUPPORTED_DISTROS="ol7 ol8 ol9 deb12 ubuntu2004 ubuntu2204 ubuntu2404 amzn2023 alpine321"
 
 # Declare an associative array, needed by docker buildx --platform option
 declare -A rev_arch_map

--- a/buildx.sh
+++ b/buildx.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2025 Mastercard
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+cleanup() {
+  echo "Caught SIGINT. Exiting..."
+  exit 1
+}
+
+trap cleanup SIGINT  # Handle SIGINT (CTRL-C)
+
+PACKAGE="pkcs11-tools"
+GITHUB_REPO="https://github.com/Mastercard/pkcs11-tools"
+GITHUB_REPO_COMMIT="HEAD"
+SUPPORTED_ARCHS="amd64 arm64"
+SUPPORTED_DISTROS="ol7 ol8 ol9 deb12 ubuntu2204 ubuntu2404 amzn2023 alpine321"
+
+# Declare an associative array, needed by docker buildx --platform option
+declare -A rev_arch_map
+rev_arch_map["x86_64"]="amd64"
+rev_arch_map["aarch64"]="arm64"
+
+#
+# Usage information
+#
+function usage() {
+    echo "Usage: $0 [-r URL] [-v] [-j N] [-c COMMIT] [-p FILE] [distro[/arch]|all[/all]] [...]"
+    echo "Supported distros: $SUPPORTED_DISTROS"
+    echo "Supported archs: $SUPPORTED_ARCHS"
+    echo ""
+    echo "Options:"
+    echo "  --repo URL, -r URL          Specify the repository URL (default: $GITHUB_REPO)"
+    echo "  --commit COMMIT, -c COMMIT  Specify the commit hash, tag or branch to build (default: $GITHUB_REPO_COMMIT)"
+    echo "  --verbose, -v               Increase verbosity (can be specified multiple times)"
+    echo "  --max-procs N, -j N         Specify the maximum number of processes"
+    echo "  --proxyrootca FILE, -x FILE Specify a root CA file to use for the build"
+    exit 1
+}
+
+#
+# Get the current directory
+#
+function get_current_dir() {
+    current_dir="$(pwd)"
+    echo "${current_dir}"
+}
+
+#
+# Get the directory of the script
+#
+function get_script_dir() {
+    script_dir="$(cd "$(dirname "$0")" && pwd)"
+    echo "${script_dir}"
+}
+
+#
+# Generate a random container name
+#
+function gen_random_container_name() {
+    random_docker_name=$(head -c 16 /dev/urandom | base64 | tr -dc 'a-z0-9' | head -c 12)
+    echo -n "container-$PACKAGE-$random_docker_name"
+}
+
+#
+# Get the current git tag or commit hash if current commit is not tagged
+#
+function get_git_tag_or_hash() {
+    # Get the current tag if it exists, otherwise get the short commit hash
+    git describe --tags --abbrev=0 2>/dev/null || git rev-parse --short HEAD
+}
+
+#
+# Copy the root CA file to the script directory (which is the context)
+#
+function copy_root_ca() {
+    local rootca="$1"
+    local script_dir=$(get_script_dir)
+
+    # Check if the file exists
+    if [ -f "$rootca" ]; then
+        cp "$rootca" "$script_dir/proxyrootca.crt"
+        echo "Root CA file copied to $script_dir/proxyrootca.crt"
+    else
+        echo "Root CA file not found: $rootca"
+        exit 1
+    fi
+}
+
+#
+# Build the tarball for the given distro and arch
+#
+# $1 - package
+# $2 - distro
+# $3 - arch
+# $4 - verbose: 0 or 1
+# $5 - repo_url (default: $GITHUB_REPO)
+# $6 - repo_branch (default: "main")
+# $7 - repo_commit (default: "HEAD")
+
+function create_build() {
+    set -e                      # Exit on error, repeated here to ensure it's set in the subshell
+
+    local package="$1"
+    local distro="$2"
+    local arch="$3"
+    local verbose="$4"
+    local repo_url="$5"
+    local repo_commit="$6"
+    local proxyrootca="$7"
+
+    local verbosearg="--quiet"
+
+    if [ "$verbose" -eq 1 ]; then
+        verbosearg="--progress=auto"
+    elif [ "$verbose" -eq 2 ]; then
+        verbosearg="--progress=plain"
+    fi
+
+    # TODO: keep this outside of this function, should be a global variable
+    declare -A arch_map
+    arch_map["amd64"]="x86_64"
+    arch_map["arm64"]="aarch64"
+
+    local platformarch="${arch_map[$arch]:-$arch}"
+
+    echo "Building artifacts for $distro on arch $arch (platform: $platformarch)..."
+    
+    local containername=$(gen_random_container_name)
+    docker buildx build $verbosearg \
+        --platform linux/$platformarch \
+        --build-arg REPO_URL=$repo_url \
+        --build-arg REPO_COMMIT_OR_TAG=$repo_commit \
+        --build-arg PROXY_ROOT_CA=$proxyrootca \
+        -t $package-build-$distro-$arch \
+        -f $(get_script_dir)/buildx/Dockerfile.$distro \
+        $(get_script_dir)
+    
+    local artifacts=$(docker run --platform linux/$platformarch --name $containername $package-build-$distro-$arch)
+    for artifact in $artifacts; do
+        docker cp --quiet $containername:$artifact $(get_current_dir)/
+    done
+    docker rm -f $containername > /dev/null 2>&1
+    echo "Done with for $distro on $arch, produced artifacts:"
+    for artifact in $artifacts; do
+        echo "  $(get_current_dir)/$(basename $artifact)"
+    done
+}
+
+# main function.
+
+#
+# Parse the arguments and execute the builds
+#
+function parse_and_build() {
+    local package="$PACKAGE"
+    local repo_url="$GITHUB_REPO"
+    local repo_commit="HEAD"
+    local verbose=0
+    local args=()
+    local numprocs=$(nproc)
+    local proxyrootca=""
+
+    # Parse optional arguments
+    while [[ "$1" == --* || "$1" == -* ]]; do
+        case "$1" in
+	    --package|-p)
+		shift
+		package="$1"
+		;;
+            --repo|-r)
+                shift
+                repo_url="$1"
+                ;;
+            --commit|-c)
+                shift
+                repo_commit="$1"
+                ;;
+            --verbose|-v)
+                if [ "$verbose" -lt 2 ]; then
+                    verbose=$(($verbose + 1))
+                fi
+                ;;
+            -vv)
+                verbose=2
+                ;;
+            --max-procs|-j)
+                shift
+                numprocs="$1"
+                # Validate the number of processes:
+                # - Must be a positive integer
+                # - Must be less than or equal to the number of CPUs
+                if ! [[ "$numprocs" =~ ^[0-9]+$ ]] || [ "$numprocs" -le 0 ] || [ "$numprocs" -gt "$(nproc)" ]; then
+                    echo "Invalid number of processes: $numprocs"
+                    usage
+                fi
+                ;;
+            --proxyrootca|-x)
+                shift
+                proxyrootca="$1"
+                ;;
+            *)
+                echo "Unknown option: $1"
+                usage
+                ;;
+        esac
+        shift
+    done
+
+    # proxy root CA must be treated from here
+    # if proxyrootca is unset, create a dummy file
+    # if proxyrootca is set, copy the root CA file to the script directory
+    if [ -z "$proxyrootca" ]; then
+        touch $(get_script_dir)/$proxyrootca
+    else
+        copy_root_ca "$proxyrootca"
+    fi
+    proxyrootca="proxyrootca.crt"
+
+    # Collect remaining arguments
+    local args=("$@")
+
+    local build_args=()
+
+    for arg in "${args[@]}"; do
+        if [[ "$arg" == "all/all" ]]; then
+            for distro in $SUPPORTED_DISTROS; do
+                for arch in $SUPPORTED_ARCHS; do
+                    build_args+=("$package $distro $arch $verbose $repo_url $repo_commit $proxyrootca")
+                done
+            done
+        elif [[ "$arg" == "all" ]]; then
+            local host_arch=$(uname -m)
+            for distro in $SUPPORTED_DISTROS; do
+                build_args+=("$package $distro $host_arch $verbose $repo_url $repo_commit $proxyrootca")
+            done
+        elif [[ "$arg" == */* ]]; then
+            IFS='/' read -r distro arch_list <<< "$arg"
+            if [[ "$arch_list" == "all" ]]; then
+                for arch in $SUPPORTED_ARCHS; do
+                    build_args+=("$package $distro $arch $verbose $repo_url $repo_commit $proxyrootca")
+                done
+            else
+                IFS=',' read -ra archs <<< "$arch_list"
+                for arch in "${archs[@]}"; do
+                    build_args+=("$package $distro $arch $verbose $repo_url $repo_commit $proxyrootca")
+                done
+            fi
+        else
+            IFS=',' read -ra distros <<< "$arg"
+            local host_arch=${rev_arch_map[$(uname -m)]:-$(uname -m)}
+            for distro in "${distros[@]}"; do
+                build_args+=("$package $distro $host_arch $verbose $repo_url $repo_commit $proxyrootca")
+            done
+        fi
+    done
+
+    export -f create_build
+    export -f get_current_dir
+    export -f get_script_dir
+    export -f gen_random_container_name
+
+    # Run builds in parallel, limiting to the number of jobs specified by the user
+    printf "%s\n" "${build_args[@]}" | xargs -P $numprocs -I {} bash -c 'create_build {}'
+}
+
+#
+# Main logic
+#
+if [[ "$#" -lt 1 ]]; then
+    usage
+fi
+
+parse_and_build "$@"
+
+# EOF

--- a/buildx.sh
+++ b/buildx.sh
@@ -242,7 +242,7 @@ function parse_and_build() {
     # if proxyrootca is unset, create a dummy file
     # if proxyrootca is set, copy the root CA file to the script directory
     if [ -z "$proxyrootca" ]; then
-        touch $(get_script_dir)/$proxyrootca
+        echo -n >$(get_script_dir)/proxyrootca.crt
     else
         copy_root_ca "$proxyrootca"
     fi

--- a/buildx/Dockerfile.alpine321
+++ b/buildx/Dockerfile.alpine321
@@ -21,6 +21,7 @@ ARG DISTRO_NAME="alpine"
 ARG DISTRO_VERSION="3.21"
 ARG DISTRO_SHORT_NAME="alpine321"
 ARG PROXY_ROOT_CA="DUMMY.pem"
+ARG CONFIG_ARGS=""
 
 # base0 is just the base image with the proxy root CA installed
 # note that if there is no proxy cert, a dummy value is used
@@ -115,10 +116,11 @@ RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAI
 
 
 FROM gitcloned AS builder
+ARG CONFIG_ARGS
 
 # Build the project
-RUN ./bootstrap.sh \
-    && ./configure --prefix=/usr \
+RUN ./bootstrap.sh --shallow-clone \
+    && ./configure --prefix=/usr $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install DESTDIR=/build
 

--- a/buildx/Dockerfile.alpine321
+++ b/buildx/Dockerfile.alpine321
@@ -41,6 +41,7 @@ RUN sed -i 's|https://|http://|' /etc/apk/repositories \
 
 FROM base0 AS base
 ARG DISTRO_SHORT_NAME
+ENV TZ=UTC
 
 # Enable the community and testing repositories for Alpine
 RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories

--- a/buildx/Dockerfile.alpine321
+++ b/buildx/Dockerfile.alpine321
@@ -1,0 +1,192 @@
+# Dockerfile for building pkcs11-tools for Alpine 3.21
+#
+# Copyright (c) 2025 Mastercard
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+ARG REPO_URL="https://github.com/Mastercard/pkcs11-tools"
+ARG REPO_COMMIT_OR_TAG="HEAD"
+ARG DISTRO_NAME="alpine"
+ARG DISTRO_VERSION="3.21"
+ARG DISTRO_SHORT_NAME="alpine321"
+ARG PROXY_ROOT_CA="DUMMY.pem"
+
+# base0 is just the base image with the proxy root CA installed
+# note that if there is no proxy cert, a dummy value is used
+FROM ${DISTRO_NAME}:${DISTRO_VERSION} AS base0
+ARG PROXY_ROOT_CA
+
+# with Alpine, we need to cheat a bit and circumvent the chicken-and-egg problem
+# of installing the proxy certs, since we need to install the ca-certificates package
+# and APK is relying upon HTTPS repositories by default
+COPY ${PROXY_ROOT_CA} /usr/local/share/ca-certificates/
+RUN sed -i 's|https://|http://|' /etc/apk/repositories \
+    && apk update \
+    && apk add --no-cache ca-certificates \
+    && update-ca-certificates \
+    && sed -i 's|http://|https://|' /etc/apk/repositories
+
+
+FROM base0 AS base
+ARG DISTRO_SHORT_NAME
+
+# Enable the community and testing repositories for Alpine
+RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+
+# Install required packages for building the project
+# coreutils is needed for 'fmt' command
+# sed is needed for string manipulation, busybox sed does not support all features
+RUN apk add --no-cache \
+    coreutils \
+    sed \
+    gawk \
+    build-base \
+    flex \
+    bison \
+    autoconf \
+    automake \
+    autoconf-archive@testing \
+    libtool \
+    pkgconf \
+    git \
+    tar \
+    bash \
+    gzip \
+    alpine-sdk \
+    sudo \
+    fakeroot \
+    openssl-dev \
+    pandoc
+
+FROM base AS gitcloned
+ARG REPO_URL
+ARG REPO_COMMIT_OR_TAG
+
+# The meta directory is used to store the version and maintainer information
+# for the RPM package
+RUN mkdir -p /meta
+
+# Clone the repository
+WORKDIR /src
+RUN git clone $REPO_URL .
+RUN git checkout $REPO_COMMIT_OR_TAG
+
+# Copy the include files for the nCipher and Luna HSMs if they are present
+RUN mkdir -p include/cryptoki
+COPY ./include/cryptoki/ncipher.* ./include/cryptoki/luna.* include/cryptoki/
+
+# Retrieve information for building APK package later
+
+# PGK_DESCRIPTION is omitted as it is not used in the APKBUILD
+# TODO: use PKG_DESCRIPTION as description in the APKBUILD
+
+# Retrieve the architecture
+RUN PKG_ARCH=$(apk --print-arch) \
+    && echo "PKG_ARCH=\"$PKG_ARCH\"" >> /meta/env
+
+# Retrieve version information from git
+# If the version is a tag, set PKG_TARVERSION to the tag, else set it to $PGK_VERSION-$PKG_RELEASE-$PKG_GITCOMMIT
+RUN PKG_VERSION=$(git describe --tags | sed -E 's/^v?([^\-]+)(-.*)?$/\1/' ) \
+    PKG_RELEASE=$(git describe --tags | sed -E 's/^v?([^\-]+)(-.*)?$/\2/; s/^-//; s/^$/0/; s/-(.*)//' ) \
+    PKG_GITCOMMIT=$(git rev-parse --short HEAD) \
+    PKG_GITSUFFIX=$(git describe --tags | sed -E 's/^v?([^\-]+)(-.*)?$/\2/;s/-([0-9]*)-g(.*)/.\2/') \
+    && echo "PKG_GITSUFFIX=\"$PKG_GITSUFFIX\"" >> /meta/env \
+    && echo "PKG_VERSION=\"$PKG_VERSION\"" >> /meta/env \
+    && echo "PKG_RELEASE=\"$PKG_RELEASE\"" >> /meta/env \
+    && echo "PKG_GITCOMMIT=\"$PKG_GITCOMMIT\"" >> /meta/env
+
+
+# Retrieve the maintainer from git
+RUN PKG_MAINTAINER=$(git log -1 --pretty=format:'%an <%ae>') \
+    && echo "PKG_MAINTAINER=\"$PKG_MAINTAINER\"" >> /meta/env
+
+RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAINER PKG_ARCH" >> /meta/env
+
+
+FROM gitcloned AS builder
+
+# Build the project
+RUN ./bootstrap.sh \
+    && ./configure --prefix=/usr \
+    && make -j $(nproc) \
+    && make install DESTDIR=/build
+
+# Install documentation
+RUN mkdir -p /build/usr/share/doc/pkcs11-tools \
+    && install -m 644 -t /build/usr/share/doc/pkcs11-tools \
+    README.md CHANGELOG.md COPYING \
+    docs/INSTALL.md \
+    docs/MANUAL.md \
+    docs/TPLICENSES.md \
+    docs/CONTRIBUTING.md
+
+
+# Final stage
+FROM builder AS final
+ARG DISTRO_SHORT_NAME
+
+RUN mkdir -p /artifacts
+
+# build the .tar.gz file
+COPY --from=builder /build /tar_build
+WORKDIR /tar_build
+RUN . /meta/env && tar -czf /artifacts/pkcs11-tools-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.tar.gz usr
+
+# build the APK package
+# Add a non-root user for building the package
+RUN adduser -D -G abuild builduser \
+    && echo "builduser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+USER builduser
+WORKDIR /home/builduser
+
+# Copy pre-built files from the builder stage
+COPY --from=builder --chown=builduser:abuild /build /home/builduser/pkgroot
+
+# Create the APKBUILD file
+RUN mkdir -p /home/builduser/apkbuild
+WORKDIR /home/builduser/apkbuild
+
+# Create the APK signing key (TODO: this should be mounted as a volume instead)
+RUN mkdir -p .abuild
+RUN abuild-keygen -a -n && echo "builduser@$(hostname)" > .abuild/identity
+RUN sudo cp ~/.abuild/*.rsa.pub /etc/apk/keys/
+
+RUN . /meta/env && cat <<EOF >APKBUILD
+# Maintainer: $PKG_MAINTAINER
+pkgname="pkcs11-tools-$DISTRO_SHORT_NAME-$PKG_ARCH"
+pkgver=$PKG_VERSION
+pkgrel=$PKG_RELEASE
+_gitcommit=$PKG_GITCOMMIT
+pkgdesc="a set of tools for manipulation of PKCS#11 objects"
+url="$REPO_URL"
+arch="$PKG_ARCH"
+license="Apache-2.0"
+makedepends="autoconf automake libtool pkgconf"
+options="!check"
+
+package() {
+    mkdir -p "\$pkgdir"
+    cp -r /home/builduser/pkgroot/* "\$pkgdir/"
+}
+
+EOF
+
+RUN mkdir -p /home/builduser/packages \
+    && echo "repository=/home/builduser/packages" >> ~/.abuild/abuild.conf
+
+RUN sudo apk update && abuild -r && sudo cp /home/builduser/packages/builduser/$(arch)/*.apk /artifacts
+
+# Final command to list the artifacts
+CMD [ "find", "/artifacts", "-type", "f" ]

--- a/buildx/Dockerfile.amzn2023
+++ b/buildx/Dockerfile.amzn2023
@@ -21,6 +21,7 @@ ARG DISTRO_NAME="amazonlinux"
 ARG DISTRO_VERSION="2023"
 ARG DISTRO_SHORT_NAME="amzn2023"
 ARG PROXY_ROOT_CA="DUMMY.pem"
+ARG CONFIG_ARGS=""
 
 # base0 is just the base image with the proxy root CA installed
 # note that if there is no proxy cert, a dummy value is used
@@ -114,10 +115,11 @@ RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAI
 
 
 FROM gitcloned AS builder
+ARG CONFIG_ARGS
 
 # Build the project for tar package (/usr/local)
-RUN ./bootstrap.sh \
-    && ./configure --with-awscloudhsm \
+RUN ./bootstrap.sh --shallow-clone \
+    && ./configure $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install DESTDIR=/tar_build
 
@@ -132,7 +134,7 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
 
 # Build again the project for RPM package (/usr)
 RUN make distclean \
-    && ./configure --prefix=/usr --with-awscloudhsm \
+    && ./configure --prefix=/usr $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install DESTDIR=/rpm_build
 

--- a/buildx/Dockerfile.amzn2023
+++ b/buildx/Dockerfile.amzn2023
@@ -33,6 +33,7 @@ RUN update-ca-trust extract
 
 FROM base0 AS base
 ARG DISTRO_SHORT_NAME
+ENV TZ=UTC
 
 # Update package repositories and install required build tools
 RUN dnf update -y && \

--- a/buildx/Dockerfile.amzn2023
+++ b/buildx/Dockerfile.amzn2023
@@ -1,4 +1,4 @@
-# Dockerfile for building pkcs11-tools for Oracle Linux 8
+# Dockerfile for building pkcs11-tools for Oracle Linux 9
 #
 # Copyright (c) 2025 Mastercard
 
@@ -13,12 +13,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 ARG REPO_URL="https://github.com/Mastercard/pkcs11-tools"
 ARG REPO_COMMIT_OR_TAG="HEAD"
-ARG DISTRO_NAME="oraclelinux"
-ARG DISTRO_VERSION="8"
-ARG DISTRO_SHORT_NAME="ol8"
+ARG DISTRO_NAME="amazonlinux"
+ARG DISTRO_VERSION="2023"
+ARG DISTRO_SHORT_NAME="amzn2023"
 ARG PROXY_ROOT_CA="DUMMY.pem"
 
 # base0 is just the base image with the proxy root CA installed
@@ -32,15 +33,11 @@ RUN update-ca-trust extract
 FROM base0 AS base
 ARG DISTRO_SHORT_NAME
 
-# ol8_codeready_builder is required to install autoconf-archive
-
-RUN OL=ol$(rpm --eval "%{rhel}") EL=el$(rpm --eval "%{rhel}") \
-    && dnf update -y \
-    && dnf --enablerepo=${OL}_codeready_builder install -y \
-    oraclelinux-developer-release-${EL}\
-    epel-release\
-    gcc\
-    make\
+# Update package repositories and install required build tools
+RUN dnf update -y && \
+    dnf install -y \
+    gcc \
+    make \
     flex \
     bison \
     automake \
@@ -56,6 +53,7 @@ RUN OL=ol$(rpm --eval "%{rhel}") EL=el$(rpm --eval "%{rhel}") \
     && dnf clean all
 
 # Deploy pandoc from github
+# aws linux 2023 does not have pandoc in the repositories
 WORKDIR /tmp
 RUN DISTROARCH=$(arch | sed 's/aarch64/arm64/;s/x86_64/amd64/') \
     && wget -q https://github.com/jgm/pandoc/releases/download/3.6/pandoc-3.6-linux-$DISTROARCH.tar.gz \
@@ -117,9 +115,9 @@ RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAI
 
 FROM gitcloned AS builder
 
-# build the project for tar package (/usr/local)
+# Build the project for tar package (/usr/local)
 RUN ./bootstrap.sh \
-    && ./configure \
+    && ./configure --with-awscloudhsm \
     && make -j $(nproc) \
     && make install DESTDIR=/tar_build
 
@@ -134,7 +132,7 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
 
 # Build again the project for RPM package (/usr)
 RUN make distclean \
-    && ./configure --prefix=/usr \
+    && ./configure --prefix=/usr --with-awscloudhsm \
     && make -j $(nproc) \
     && make install DESTDIR=/rpm_build
 
@@ -146,7 +144,6 @@ RUN mkdir -p /rpm_build/usr/share/doc/pkcs11-tools \
     docs/MANUAL.md \
     docs/TPLICENSES.md \
     docs/CONTRIBUTING.md
-
 
 # Final stage
 FROM builder AS final
@@ -176,7 +173,7 @@ Release:        1$PKG_GITSUFFIX%{?dist}
 Summary:        a set of tools for manipulation of PKCS#11 objects
 License:        Apache-2.0
 URL:            $REPO_URL
-BuildRequires:  gcc, make, automake, autoconf, libtool, git, tar, gzip, rpm-build, autoconf-archive
+BuildRequires:  gcc, make, automake, autoconf, libtool, autoconf-archive
 %description
 $PKG_DESCRIPTION
 
@@ -192,8 +189,6 @@ cp -r %{_sourcedir}/prebuilt/usr %{buildroot}
 
 %changelog
 EOF
-
-RUN cat  /root/rpmbuild/SPECS/pkcs11-tools.spec
 
 # Build the RPM package
 RUN . /meta/env \

--- a/buildx/Dockerfile.deb12
+++ b/buildx/Dockerfile.deb12
@@ -30,6 +30,9 @@ COPY ${PROXY_ROOT_CA} /usr/local/share/ca-certificates/${PROXY_ROOT_CA}
 RUN apt-get update && apt-get install -y ca-certificates
 
 FROM base0 AS base
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
 # Install required packages for building the project
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/buildx/Dockerfile.deb12
+++ b/buildx/Dockerfile.deb12
@@ -1,0 +1,172 @@
+# Dockerfile for building pkcs11-tools for Debian 12
+#
+# Copyright (c) 2025 Mastercard
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG REPO_URL="https://github.com/Mastercard/pkcs11-tools"
+ARG REPO_COMMIT_OR_TAG="HEAD"
+ARG DISTRO_NAME="debian"
+ARG DISTRO_VERSION="12"
+ARG DISTRO_SHORT_NAME="deb12"
+ARG PROXY_ROOT_CA="DUMMY.pem"
+
+# base0 is just the base image with the proxy root CA installed
+# note that if there is no proxy cert, a dummy value is used
+FROM ${DISTRO_NAME}:${DISTRO_VERSION} AS base0
+ARG PROXY_ROOT_CA
+COPY ${PROXY_ROOT_CA} /usr/local/share/ca-certificates/${PROXY_ROOT_CA}
+RUN apt-get update && apt-get install -y ca-certificates
+
+FROM base0 AS base
+# Install required packages for building the project
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    autoconf \
+    autoconf-archive \
+    automake \
+    libtool \
+    pkgconf \
+    make \
+    perl \
+    libssl-dev \
+    gawk \
+    git \
+    tar \
+    gzip \
+    pandoc \
+    dpkg-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM base AS gitcloned
+ARG REPO_URL
+ARG REPO_COMMIT_OR_TAG
+
+# The meta directory is used to store the version and maintainer information
+# for the DEB package
+RUN mkdir -p /meta
+
+# Clone the repository
+WORKDIR /src
+RUN git clone $REPO_URL .
+RUN git checkout $REPO_COMMIT_OR_TAG
+
+# Copy the include files for the nCipher and Luna HSMs if they are present
+RUN mkdir -p include/cryptoki
+COPY ./include/cryptoki/ncipher.* ./include/cryptoki/luna.* include/cryptoki/
+
+# Retrieve information for building DEB package later
+
+# Retrieve the architecture
+RUN PKG_ARCH=$(dpkg --print-architecture) \
+    && echo "PKG_ARCH=\"$PKG_ARCH\"" >> /meta/env
+
+# Retrieve version information from git
+# If the version is a tag, set PKG_GITSUFFIX to the tag, or to '~<commit>' if the tag is not the last commit
+RUN PKG_VERSION=$(git describe --tags | sed -E 's/^v([^\-]+)(-.*)?$/\1/' ) \
+    PKG_RELEASE=$(git describe --tags | sed -E 's/^v([^\-]+)(-.*)?$/\2/; s/^-//; s/^$/0/; s/-(.*)//' ) \
+    PKG_GITCOMMIT=$(git rev-parse --short HEAD) \
+    PKG_GITSUFFIX=$(git describe --tags | sed -E 's/^v([^\-]+)(-.*)?$/\2/;s/-([0-9]*)-g(.*)/~\2/') \
+    && echo "PKG_GITSUFFIX=\"$PKG_GITSUFFIX\"" >> /meta/env \
+    && echo "PKG_VERSION=\"$PKG_VERSION\"" >> /meta/env \
+    && echo "PKG_RELEASE=\"$PKG_RELEASE\"" >> /meta/env \
+    && echo "PKG_GITCOMMIT=\"$PKG_GITCOMMIT\"" >> /meta/env
+
+# Retrieve the maintainer from git
+RUN PKG_MAINTAINER=$(git log -1 --pretty=format:'%an <%ae>') \
+    && echo "PKG_MAINTAINER=\"$PKG_MAINTAINER\"" >> /meta/env
+
+# Retrieve description from README.md
+# This is a bit more complex as we need to strip out the first heading
+# and the first line of the second heading
+# moreover, any occurrence of '`' should be removed to avoid issues with
+# the shell
+RUN PKG_DESCRIPTION=$(cat README.md \
+    | awk '/## Introduction/{flag=1} /## Download/{flag=0} flag' \
+    | sed '/^##.*/d' \
+    | pandoc -f markdown -t plain \
+    | sed '/^[[:space:]]*$/d' \
+    | sed '1!s/^/ /')\
+    && echo "PKG_DESCRIPTION=\"$PKG_DESCRIPTION\"" >> /meta/env
+
+
+RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAINER PKG_ARCH" >> /meta/env
+
+
+FROM gitcloned AS builder
+
+# Build the project for tar package (/usr/local)
+RUN ./bootstrap.sh \
+    && ./configure \
+    && make -j $(nproc)\
+    && make install-strip DESTDIR=/tar_build
+
+# Install documentation
+RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
+    && install -m 644 -t /tar_build/usr/local/share/doc/pkcs11-tools \
+    README.md CHANGELOG.md COPYING \
+    docs/INSTALL.md \
+    docs/MANUAL.md \
+    docs/TPLICENSES.md \
+    docs/CONTRIBUTING.md
+
+# Build again the project for deb package (/usr)
+RUN make distclean \
+    && ./configure --prefix=/usr --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
+    && make -j $(nproc) \
+    && make install-strip DESTDIR=/deb_build
+
+# Install documentation
+RUN mkdir -p /deb_build/usr/share/doc/pkcs11-tools \
+    && install -m 644 -t /deb_build/usr/share/doc/pkcs11-tools \
+    README.md CHANGELOG.md COPYING \
+    docs/INSTALL.md \
+    docs/MANUAL.md \
+    docs/TPLICENSES.md \
+    docs/CONTRIBUTING.md
+
+# Final stage
+FROM builder AS final
+ARG DISTRO_SHORT_NAME
+
+RUN mkdir -p /artifacts
+
+# build the .tar.gz package
+WORKDIR /tar_build
+RUN . /meta/env && tar -czf /artifacts/pkcs11-tools-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.tar.gz usr
+
+# build the deb package
+WORKDIR /deb_build
+RUN mkdir -p DEBIAN /artifacts
+
+# Create control file for the package
+RUN . /meta/env \
+    && echo "Package: pkcs11-tools" > DEBIAN/control \
+    && echo "Homepage: $REPO_URL" >> DEBIAN/control \
+    && echo "License: Apache 2.0" >> DEBIAN/control \
+    && echo "Version: $PKG_VERSION$PKG_GITSUFFIX" >> DEBIAN/control \
+    && echo "X-Vcs-Git: $REPO_URL" >> DEBIAN/control \
+    && echo "X-Git-Commit: $PKG_GITCOMMIT" >> DEBIAN/control \
+    && echo "Section: utils" >> DEBIAN/control \
+    && echo "Priority: optional" >> DEBIAN/control \
+    && echo "Architecture: $PKG_ARCH" >> DEBIAN/control \
+    && echo "Depends: libc6 (>= 2.34), libssl3" >> DEBIAN/control \
+    && echo "Maintainer: $PKG_MAINTAINER" >> DEBIAN/control \
+    && echo "Description: a set of tools for manipulation of PKCS#11 objects" >> DEBIAN/control
+
+# Build the .deb package
+RUN . /meta/env \
+    && dpkg-deb --build /deb_build /artifacts/pkcs11-tools-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.deb
+
+# Final command to list the artifacts
+CMD [ "find", "/artifacts", "-type", "f" ]

--- a/buildx/Dockerfile.deb12
+++ b/buildx/Dockerfile.deb12
@@ -20,6 +20,7 @@ ARG DISTRO_NAME="debian"
 ARG DISTRO_VERSION="12"
 ARG DISTRO_SHORT_NAME="deb12"
 ARG PROXY_ROOT_CA="DUMMY.pem"
+ARG CONFIG_ARGS=""
 
 # base0 is just the base image with the proxy root CA installed
 # note that if there is no proxy cert, a dummy value is used
@@ -92,7 +93,7 @@ RUN PKG_MAINTAINER=$(git log -1 --pretty=format:'%an <%ae>') \
 # moreover, any occurrence of '`' should be removed to avoid issues with
 # the shell
 RUN PKG_DESCRIPTION=$(cat README.md \
-    | awk '/## Introduction/{flag=1} /## Download/{flag=0} flag' \
+    | awk '/# PKCS\\#11 tools/{flag=1} /Some features:/{flag=0} flag' \
     | sed '/^##.*/d' \
     | pandoc -f markdown -t plain \
     | sed '/^[[:space:]]*$/d' \
@@ -104,10 +105,11 @@ RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAI
 
 
 FROM gitcloned AS builder
+ARG CONFIG_ARGS
 
 # Build the project for tar package (/usr/local)
-RUN ./bootstrap.sh \
-    && ./configure \
+RUN ./bootstrap.sh --shallow-clone \
+    && ./configure $CONFIG_ARGS \
     && make -j $(nproc)\
     && make install-strip DESTDIR=/tar_build
 
@@ -122,7 +124,7 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
 
 # Build again the project for deb package (/usr)
 RUN make distclean \
-    && ./configure --prefix=/usr --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
+    && ./configure --prefix=/usr --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install-strip DESTDIR=/deb_build
 

--- a/buildx/Dockerfile.ol7
+++ b/buildx/Dockerfile.ol7
@@ -172,7 +172,7 @@ COPY --from=builder /rpm_build /root/rpmbuild/SOURCES/prebuilt
 
 # Create the RPM spec file
 RUN . /meta/env && cat <<EOF > /root/rpmbuild/SPECS/pkcs-tools.spec
-Name:           pkcs-tools
+Name:           pkcs11-tools
 Version:        $PKG_VERSION
 Release:        1$PKG_GITSUFFIX%{?dist}
 Summary:        a set of tools for manipulation of PKCS#11 objects

--- a/buildx/Dockerfile.ol7
+++ b/buildx/Dockerfile.ol7
@@ -1,4 +1,4 @@
-# Dockerfile for building pkcs11-tools for Oracle Linux 8
+# Dockerfile for building pkcs11-tools for Oracle Linux 7
 #
 # Copyright (c) 2025 Mastercard
 
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG REPO_URL="https://github.com/Mastercard/pkcs11-tools"
+ARG REPO_URL="https://github.com/Mastercard/libpkcs11shim"
 ARG REPO_COMMIT_OR_TAG="HEAD"
 ARG DISTRO_NAME="oraclelinux"
-ARG DISTRO_VERSION="8"
-ARG DISTRO_SHORT_NAME="ol8"
+ARG DISTRO_VERSION="7"
+ARG DISTRO_SHORT_NAME="ol7"
 ARG PROXY_ROOT_CA="DUMMY.pem"
 
 # base0 is just the base image with the proxy root CA installed
@@ -32,28 +32,25 @@ RUN update-ca-trust extract
 FROM base0 AS base
 ARG DISTRO_SHORT_NAME
 
-# ol8_codeready_builder is required to install autoconf-archive
-
+# Enable software collection for OL7 and deploy GCC 10 and other packages
 RUN OL=ol$(rpm --eval "%{rhel}") EL=el$(rpm --eval "%{rhel}") \
-    && dnf update -y \
-    && dnf --enablerepo=${OL}_codeready_builder install -y \
-    oraclelinux-developer-release-${EL}\
-    epel-release\
-    gcc\
-    make\
+    && yum update -y \
+    && yum install -y oracle-softwarecollection-release-${EL} oracle-epel-release-${EL} \
+    && yum install -y \
+    autoconf \
+    autoconf-archive \
     flex \
     bison \
     automake \
-    autoconf \
-    autoconf-archive \
     libtool \
     git \
     tar \
     gzip \
+    devtoolset-10-gcc \
     rpm-build \
     wget \
-    openssl-devel \
-    && dnf clean all
+    openssl11-devel \
+    && yum clean all
 
 # Deploy pandoc from github
 WORKDIR /tmp
@@ -79,6 +76,7 @@ RUN git checkout $REPO_COMMIT_OR_TAG
 # Copy the include files for the nCipher and Luna HSMs if they are present
 RUN mkdir -p include/cryptoki
 COPY ./include/cryptoki/ncipher.* ./include/cryptoki/luna.* include/cryptoki/
+
 # Retrieve information for building RPM package later
 
 # Retrieve the architecture
@@ -112,16 +110,17 @@ RUN PKG_DESCRIPTION=$(cat README.md \
     | sed '/^[[:space:]]*$/d') \
     && echo "PKG_DESCRIPTION=\"$PKG_DESCRIPTION\"" >> /meta/env
 
-RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAINER PKG_ARCH" >> /meta/env
+    RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAINER PKG_ARCH" >> /meta/env
 
 
 FROM gitcloned AS builder
 
 # build the project for tar package (/usr/local)
-RUN ./bootstrap.sh \
+RUN scl enable devtoolset-10 \
+    "./bootstrap.sh \
     && ./configure \
     && make -j $(nproc) \
-    && make install DESTDIR=/tar_build
+    && make install DESTDIR=/tar_build"
 
 # install documentation
 RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
@@ -133,10 +132,11 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
     docs/CONTRIBUTING.md
 
 # Build again the project for deb package (/usr)
-RUN make distclean \
+RUN scl enable devtoolset-10 \
+    "make distclean \
     && ./configure --prefix=/usr \
     && make -j $(nproc) \
-    && make install DESTDIR=/rpm_build
+    && make install DESTDIR=/rpm_build"
 
 # Install documentation
 RUN mkdir -p /rpm_build/usr/share/doc/pkcs11-tools \
@@ -156,7 +156,7 @@ RUN mkdir -p /artifacts
 
 # build the .tar.gz file
 WORKDIR /tar_build
-RUN . /meta/env && tar -czf /artifacts/pkcs11-tools-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.tar.gz usr
+RUN . /meta/env && tar -czf /artifacts/pkcs-tools-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.tar.gz usr
 
 # build the RPM package
 WORKDIR /root
@@ -164,19 +164,19 @@ WORKDIR /root
 # Create the RPM spec file
 RUN mkdir -p /root/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
-
 # Copy the build artifacts to the SOURCES directory
 COPY --from=builder /rpm_build /root/rpmbuild/SOURCES/prebuilt
 
 # Create the RPM spec file
-RUN . /meta/env && cat <<EOF > /root/rpmbuild/SPECS/pkcs11-tools.spec
-Name:           pkcs11-tools
+RUN . /meta/env && cat <<EOF > /root/rpmbuild/SPECS/pkcs-tools.spec
+Name:           pkcs-tools
 Version:        $PKG_VERSION
 Release:        1$PKG_GITSUFFIX%{?dist}
 Summary:        a set of tools for manipulation of PKCS#11 objects
 License:        Apache-2.0
 URL:            $REPO_URL
-BuildRequires:  gcc, make, automake, autoconf, libtool, git, tar, gzip, rpm-build, autoconf-archive
+BuildRequires:  gcc, make, automake, autoconf, libtool, autoconf-archive
+
 %description
 $PKG_DESCRIPTION
 
@@ -193,15 +193,13 @@ cp -r %{_sourcedir}/prebuilt/usr %{buildroot}
 %changelog
 EOF
 
-RUN cat  /root/rpmbuild/SPECS/pkcs11-tools.spec
-
 # Build the RPM package
 RUN . /meta/env \
-    && rpmbuild -ba /root/rpmbuild/SPECS/pkcs11-tools.spec
+    && rpmbuild -ba /root/rpmbuild/SPECS/pkcs-tools.spec
 
 # Copy the RPM package to the artifacts directory
 RUN . /meta/env \
-    && cp /root/rpmbuild/RPMS/$PKG_ARCH/pkcs11-tools-${PKG_VERSION}-1${PKG_GITSUFFIX}$(rpm --eval "%{dist}").${PKG_ARCH}.rpm /artifacts
+    && cp /root/rpmbuild/RPMS/$PKG_ARCH/pkcs-tools-${PKG_VERSION}-1${PKG_GITSUFFIX}$(rpm --eval "%{dist}").${PKG_ARCH}.rpm /artifacts
 
 # Final command to list the artifacts
 CMD [ "find", "/artifacts", "-type", "f" ]

--- a/buildx/Dockerfile.ol7
+++ b/buildx/Dockerfile.ol7
@@ -131,7 +131,7 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
     docs/TPLICENSES.md \
     docs/CONTRIBUTING.md
 
-# Build again the project for deb package (/usr)
+# Build again the project for RPM package (/usr)
 RUN scl enable devtoolset-10 \
     "make distclean \
     && ./configure --prefix=/usr \

--- a/buildx/Dockerfile.ol7
+++ b/buildx/Dockerfile.ol7
@@ -20,6 +20,7 @@ ARG DISTRO_NAME="oraclelinux"
 ARG DISTRO_VERSION="7"
 ARG DISTRO_SHORT_NAME="ol7"
 ARG PROXY_ROOT_CA="DUMMY.pem"
+ARG CONFIG_ARGS=""
 
 # base0 is just the base image with the proxy root CA installed
 # note that if there is no proxy cert, a dummy value is used
@@ -43,7 +44,7 @@ RUN OL=ol$(rpm --eval "%{rhel}") EL=el$(rpm --eval "%{rhel}") \
     bison \
     automake \
     libtool \
-    git \
+    rh-git218-git-core \
     tar \
     gzip \
     devtoolset-10-gcc \
@@ -70,8 +71,9 @@ RUN mkdir -p /meta
 
 # Clone the repository
 WORKDIR /src
-RUN git clone $REPO_URL .
-RUN git checkout $REPO_COMMIT_OR_TAG
+RUN scl enable rh-git218 \
+    "git clone $REPO_URL . \
+    && git checkout $REPO_COMMIT_OR_TAG"
 
 # Copy the include files for the nCipher and Luna HSMs if they are present
 RUN mkdir -p include/cryptoki
@@ -85,17 +87,17 @@ RUN PKG_ARCH=$(rpm --eval '%{_arch}') \
 
 # Retrieve version information from git
 # If the version is a tag, set PKG_GITSUFFIX to the tag, or to '~<commit>' if the tag is not the last commit
-RUN PKG_VERSION=$(git describe --tags | sed -E 's/^v?([^\-]+)(-.*)?$/\1/' ) \
-    PKG_RELEASE=$(git describe --tags | sed -E 's/^v?([^\-]+)(-.*)?$/\2/; s/^-//; s/^$/0/; s/-(.*)//' ) \
-    PKG_GITCOMMIT=$(git rev-parse --short HEAD) \
-    PKG_GITSUFFIX=$(git describe --tags | sed -E 's/^v?([^\-]+)(-.*)?$/\2/;s/-([0-9]*)-g(.*)/.\2/') \
+RUN PKG_VERSION=$(scl enable rh-git218 "git describe --tags" | sed -E 's/^v?([^\-]+)(-.*)?$/\1/' ) \
+    PKG_RELEASE=$(scl enable rh-git218 "git describe --tags" | sed -E 's/^v?([^\-]+)(-.*)?$/\2/; s/^-//; s/^$/0/; s/-(.*)//' ) \
+    PKG_GITCOMMIT=$(scl enable rh-git218 "git rev-parse --short HEAD") \
+    PKG_GITSUFFIX=$(scl enable rh-git218 "git describe --tags" | sed -E 's/^v?([^\-]+)(-.*)?$/\2/;s/-([0-9]*)-g(.*)/.\2/') \
     && echo "PKG_GITSUFFIX=\"$PKG_GITSUFFIX\"" >> /meta/env \
     && echo "PKG_VERSION=\"$PKG_VERSION\"" >> /meta/env \
     && echo "PKG_RELEASE=\"$PKG_RELEASE\"" >> /meta/env \
     && echo "PKG_GITCOMMIT=\"$PKG_GITCOMMIT\"" >> /meta/env
 
 # Retrieve the maintainer from git
-RUN PKG_MAINTAINER=$(git log -1 --pretty=format:'%an <%ae>') \
+RUN PKG_MAINTAINER=$(scl enable rh-git218 "git log -1 --pretty=format:'%an <%ae>'") \
     && echo "PKG_MAINTAINER=\"$PKG_MAINTAINER\"" >> /meta/env
 
 # Retrieve description from README.md
@@ -114,11 +116,12 @@ RUN PKG_DESCRIPTION=$(cat README.md \
 
 
 FROM gitcloned AS builder
+ARG CONFIG_ARGS
 
 # build the project for tar package (/usr/local)
-RUN scl enable devtoolset-10 \
-    "./bootstrap.sh \
-    && ./configure \
+RUN scl enable devtoolset-10 rh-git218 \
+    "./bootstrap.sh --shallow-clone\
+    && ./configure $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install DESTDIR=/tar_build"
 
@@ -132,9 +135,9 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
     docs/CONTRIBUTING.md
 
 # Build again the project for RPM package (/usr)
-RUN scl enable devtoolset-10 \
+RUN scl enable devtoolset-10 rh-git218 \
     "make distclean \
-    && ./configure --prefix=/usr \
+    && ./configure --prefix=/usr $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install DESTDIR=/rpm_build"
 

--- a/buildx/Dockerfile.ol7
+++ b/buildx/Dockerfile.ol7
@@ -32,6 +32,7 @@ RUN update-ca-trust extract
 
 FROM base0 AS base
 ARG DISTRO_SHORT_NAME
+ENV TZ=UTC
 
 # Enable software collection for OL7 and deploy GCC 10 and other packages
 RUN OL=ol$(rpm --eval "%{rhel}") EL=el$(rpm --eval "%{rhel}") \

--- a/buildx/Dockerfile.ol8
+++ b/buildx/Dockerfile.ol8
@@ -32,6 +32,7 @@ RUN update-ca-trust extract
 
 FROM base0 AS base
 ARG DISTRO_SHORT_NAME
+ENV TZ=UTC
 
 # ol8_codeready_builder is required to install autoconf-archive
 

--- a/buildx/Dockerfile.ol8
+++ b/buildx/Dockerfile.ol8
@@ -20,6 +20,7 @@ ARG DISTRO_NAME="oraclelinux"
 ARG DISTRO_VERSION="8"
 ARG DISTRO_SHORT_NAME="ol8"
 ARG PROXY_ROOT_CA="DUMMY.pem"
+ARG CONFIG_ARGS=""
 
 # base0 is just the base image with the proxy root CA installed
 # note that if there is no proxy cert, a dummy value is used
@@ -116,10 +117,11 @@ RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAI
 
 
 FROM gitcloned AS builder
+ARG CONFIG_ARGS
 
 # build the project for tar package (/usr/local)
-RUN ./bootstrap.sh \
-    && ./configure \
+RUN ./bootstrap.sh --shallow-clone \
+    && ./configure $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install DESTDIR=/tar_build
 
@@ -134,7 +136,7 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
 
 # Build again the project for RPM package (/usr)
 RUN make distclean \
-    && ./configure --prefix=/usr \
+    && ./configure --prefix=/usr $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install DESTDIR=/rpm_build
 

--- a/buildx/Dockerfile.ol8
+++ b/buildx/Dockerfile.ol8
@@ -1,4 +1,4 @@
-# Dockerfile for building pkcs11-tools for Oracle Linux 9
+# Dockerfile for building pkcs11-tools for Oracle Linux 8
 #
 # Copyright (c) 2025 Mastercard
 
@@ -17,8 +17,8 @@
 ARG REPO_URL="https://github.com/Mastercard/pkcs11-tools"
 ARG REPO_COMMIT_OR_TAG="HEAD"
 ARG DISTRO_NAME="oraclelinux"
-ARG DISTRO_VERSION="9"
-ARG DISTRO_SHORT_NAME="ol9"
+ARG DISTRO_VERSION="8"
+ARG DISTRO_SHORT_NAME="ol8"
 ARG PROXY_ROOT_CA="DUMMY.pem"
 
 # base0 is just the base image with the proxy root CA installed
@@ -31,24 +31,24 @@ RUN dnf update -y && dnf install -y ca-certificates
 FROM base0 AS base
 ARG DISTRO_SHORT_NAME
 
-# ol9_codeready_builder is required to install autoconf-archive
+# ol8_codeready_builder is required to install autoconf-archive
 
 RUN OL=$(rpm --eval "%{dist}" | sed s/.e/o/) EL=$(rpm --eval "%{dist}" | sed s/.//) \
     && dnf --enablerepo=${OL}_codeready_builder install -y \
-    oraclelinux-developer-release-${EL} \
-    epel-release \
-    gcc \
-    make \
+    oraclelinux-developer-release-${EL}\
+    epel-release\
+    gcc\
+    make\
     flex \
-    automake \
-    autoconf \
-    autoconf-archive \
-    libtool \
-    git \
-    tar \
-    gzip \
-    rpm-build \
-    wget \ 
+    automake\
+    autoconf\
+    autoconf-archive\
+    libtool\
+    git\
+    tar\
+    gzip\
+    rpm-build\
+    wget \
     openssl-devel \
     && dnf clean all
 
@@ -59,7 +59,7 @@ RUN DISTROARCH=$(arch | sed 's/aarch64/arm64/;s/x86_64/amd64/') \
     && tar -xf pandoc-3.6-linux-$DISTROARCH.tar.gz -C /usr/local --strip-components 1 \
     && rm pandoc-3.6-linux-$DISTROARCH.tar.gz
 
-    
+
 FROM base AS gitcloned
 ARG REPO_URL
 ARG REPO_COMMIT_OR_TAG
@@ -76,7 +76,6 @@ RUN git checkout $REPO_COMMIT_OR_TAG
 # Copy the include files for the nCipher and Luna HSMs if they are present
 RUN mkdir -p include/cryptoki
 COPY ./include/cryptoki/ncipher.* ./include/cryptoki/luna.* include/cryptoki/
-
 # Retrieve information for building RPM package later
 
 # Retrieve the architecture
@@ -117,11 +116,11 @@ FROM gitcloned AS builder
 
 # build the project for tar package (/usr/local)
 RUN ./bootstrap.sh \
-    && ./configure \
+    && ./configure CFLAGS=-Wno-error=unused-label \
     && make -j $(nproc) \
     && make install DESTDIR=/tar_build
 
-# Install documentation
+# install documentation
 RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
     && install -m 644 -t /tar_build/usr/local/share/doc/pkcs11-tools \
     README.md CHANGELOG.md COPYING \
@@ -130,9 +129,9 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
     docs/TPLICENSES.md \
     docs/CONTRIBUTING.md
 
-# Build again the project for rpm package (/usr)
+# Build again the project for deb package (/usr)
 RUN make distclean \
-    && ./configure --prefix=/usr \
+    && ./configure --prefix=/usr CFLAGS=-Wno-error=unused-label \
     && make -j $(nproc) \
     && make install DESTDIR=/rpm_build
 
@@ -162,6 +161,7 @@ WORKDIR /root
 # Create the RPM spec file
 RUN mkdir -p /root/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
+
 # Copy the build artifacts to the SOURCES directory
 COPY --from=builder /rpm_build /root/rpmbuild/SOURCES/prebuilt
 
@@ -173,8 +173,7 @@ Release:        1$PKG_GITSUFFIX%{?dist}
 Summary:        a set of tools for manipulation of PKCS#11 objects
 License:        Apache-2.0
 URL:            $REPO_URL
-BuildRequires:  gcc, make, automake, autoconf, libtool, autoconf-archive
-
+BuildRequires:  gcc, make, automake, autoconf, libtool, git, tar, gzip, rpm-build, autoconf-archive
 %description
 $PKG_DESCRIPTION
 
@@ -190,6 +189,8 @@ cp -r %{_sourcedir}/prebuilt/usr %{buildroot}
 
 %changelog
 EOF
+
+RUN cat  /root/rpmbuild/SPECS/pkcs11-tools.spec
 
 # Build the RPM package
 RUN . /meta/env \

--- a/buildx/Dockerfile.ol9
+++ b/buildx/Dockerfile.ol9
@@ -1,0 +1,203 @@
+# Dockerfile for building pkcs11-tools for Oracle Linux 9
+#
+# Copyright (c) 2025 Mastercard
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG REPO_URL="https://github.com/Mastercard/pkcs11-tools"
+ARG REPO_COMMIT_OR_TAG="HEAD"
+ARG DISTRO_NAME="oraclelinux"
+ARG DISTRO_VERSION="9"
+ARG DISTRO_SHORT_NAME="ol9"
+ARG PROXY_ROOT_CA="DUMMY.pem"
+
+# base0 is just the base image with the proxy root CA installed
+# note that if there is no proxy cert, a dummy value is used
+FROM ${DISTRO_NAME}:${DISTRO_VERSION} AS base0
+ARG PROXY_ROOT_CA
+COPY ${PROXY_ROOT_CA} /usr/local/share/ca-certificates/${PROXY_ROOT_CA}
+RUN dnf update -y && dnf install -y ca-certificates
+
+FROM base0 AS base
+ARG DISTRO_SHORT_NAME
+
+# ol9_codeready_builder is required to install autoconf-archive
+
+RUN OL=$(rpm --eval "%{dist}" | sed s/.e/o/) EL=$(rpm --eval "%{dist}" | sed s/.//) \
+    && dnf --enablerepo=${OL}_codeready_builder install -y \
+    oraclelinux-developer-release-${EL} \
+    epel-release \
+    gcc \
+    make \
+    flex \
+    automake \
+    autoconf \
+    autoconf-archive \
+    libtool \
+    git \
+    tar \
+    gzip \
+    rpm-build \
+    wget \ 
+    openssl-devel \
+    && dnf clean all
+
+# Deploy pandoc from github
+WORKDIR /tmp
+RUN DISTROARCH=$(arch | sed 's/aarch64/arm64/;s/x86_64/amd64/') \
+    && wget -q https://github.com/jgm/pandoc/releases/download/3.6/pandoc-3.6-linux-$DISTROARCH.tar.gz \
+    && tar -xf pandoc-3.6-linux-$DISTROARCH.tar.gz -C /usr/local --strip-components 1 \
+    && rm pandoc-3.6-linux-$DISTROARCH.tar.gz
+
+    
+FROM base AS gitcloned
+ARG REPO_URL
+ARG REPO_COMMIT_OR_TAG
+
+# The meta directory is used to store the version and maintainer information
+# for the RPM package
+RUN mkdir -p /meta
+
+# Clone the repository
+WORKDIR /src
+RUN git clone $REPO_URL .
+RUN git checkout $REPO_COMMIT_OR_TAG
+
+# Copy the include files for the nCipher and Luna HSMs if they are present
+RUN mkdir -p include/cryptoki
+COPY ./include/cryptoki/ncipher.* ./include/cryptoki/luna.* include/cryptoki/
+
+# Retrieve information for building RPM package later
+
+# Retrieve the architecture
+RUN PKG_ARCH=$(rpm --eval '%{_arch}') \
+    && echo "PKG_ARCH=\"$PKG_ARCH\"" >> /meta/env
+
+# Retrieve version information from git
+# If the version is a tag, set PKG_GITSUFFIX to the tag, or to '~<commit>' if the tag is not the last commit
+RUN PKG_VERSION=$(git describe --tags | sed -E 's/^([^\-]+)(-.*)?$/\1/' ) \
+    PKG_RELEASE=$(git describe --tags | sed -E 's/^([^\-]+)(-.*)?$/\2/; s/^-//; s/^$/0/; s/-(.*)//' ) \
+    PKG_GITCOMMIT=$(git rev-parse --short HEAD) \
+    PKG_GITSUFFIX=$(git describe --tags | sed -E 's/^([^\-]+)(-.*)?$/\2/;s/-([0-9]*)-g(.*)/~\2/') \
+    && echo "PKG_GITSUFFIX=\"$PKG_GITSUFFIX\"" >> /meta/env \
+    && echo "PKG_VERSION=\"$PKG_VERSION\"" >> /meta/env \
+    && echo "PKG_RELEASE=\"$PKG_RELEASE\"" >> /meta/env \
+    && echo "PKG_GITCOMMIT=\"$PKG_GITCOMMIT\"" >> /meta/env
+
+# Retrieve the maintainer from git
+RUN PKG_MAINTAINER=$(git log -1 --pretty=format:'%an <%ae>') \
+    && echo "PKG_MAINTAINER=\"$PKG_MAINTAINER\"" >> /meta/env
+
+# Retrieve description from README.md
+# This is a bit more complex as we need to strip out the first heading
+# and the first line of the second heading
+# moreover, any occurrence of '`' should be removed to avoid issues with
+# the shell
+RUN PKG_DESCRIPTION=$(cat README.md \
+    | awk '/## Introduction/{flag=1} /## Download/{flag=0} flag' \
+    | sed '/^##.*/d' \
+    | pandoc -f markdown -t plain \
+    | sed '/^[[:space:]]*$/d') \
+    && echo "PKG_DESCRIPTION=\"$PKG_DESCRIPTION\"" >> /meta/env
+
+RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAINER PKG_ARCH" >> /meta/env
+
+
+FROM gitcloned AS builder
+
+# build the project for tar package (/usr/local)
+RUN ./bootstrap.sh \
+    && ./configure \
+    && make -j $(nproc) \
+    && make install DESTDIR=/tar_build
+
+# Install documentation
+RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
+    && install -m 644 -t /tar_build/usr/local/share/doc/pkcs11-tools \
+    README.md CHANGELOG.md COPYING \
+    docs/INSTALL.md \
+    docs/MANUAL.md \
+    docs/TPLICENSES.md \
+    docs/CONTRIBUTING.md
+
+# Build again the project for rpm package (/usr)
+RUN make distclean \
+    && ./configure --prefix=/usr \
+    && make -j $(nproc) \
+    && make install DESTDIR=/rpm_build
+
+# Install documentation
+RUN mkdir -p /rpm_build/usr/share/doc/pkcs11-tools \
+    && install -m 644 -t /rpm_build/usr/share/doc/pkcs11-tools \
+    README.md CHANGELOG.md COPYING \
+    docs/INSTALL.md \
+    docs/MANUAL.md \
+    docs/TPLICENSES.md \
+    docs/CONTRIBUTING.md
+
+
+# Final stage
+FROM builder AS final
+ARG DISTRO_SHORT_NAME
+
+RUN mkdir -p /artifacts
+
+# build the .tar.gz file
+WORKDIR /tar_build
+RUN . /meta/env && tar -czf /artifacts/pkcs11-tools-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.tar.gz usr
+
+# build the RPM package
+WORKDIR /root
+
+# Create the RPM spec file
+RUN mkdir -p /root/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+# Copy the build artifacts to the SOURCES directory
+COPY --from=builder /rpm_build /root/rpmbuild/SOURCES/prebuilt
+
+# Create the RPM spec file
+RUN . /meta/env && cat <<EOF > /root/rpmbuild/SPECS/pkcs11-tools.spec
+Name:           pkcs11-tools
+Version:        $PKG_VERSION
+Release:        1$PKG_GITSUFFIX%{?dist}
+Summary:        a set of tools for manipulation of PKCS#11 objects
+License:        Apache-2.0
+URL:            $REPO_URL
+BuildRequires:  gcc, make, automake, autoconf, libtool, autoconf-archive
+
+%description
+$PKG_DESCRIPTION
+
+%install
+mkdir -p %{buildroot}
+cp -r %{_sourcedir}/prebuilt/usr %{buildroot}
+
+%files
+%{_bindir}/*
+
+%doc
+%{_docdir}/pkcs11-tools
+
+%changelog
+EOF
+
+# Build the RPM package
+RUN . /meta/env \
+    && rpmbuild -ba /root/rpmbuild/SPECS/pkcs11-tools.spec
+
+# Copy the RPM package to the artifacts directory
+RUN . /meta/env \
+    && cp /root/rpmbuild/RPMS/$PKG_ARCH/pkcs11-tools-${PKG_VERSION}-1${PKG_GITSUFFIX}$(rpm --eval "%{dist}").${PKG_ARCH}.rpm /artifacts
+
+# Final command to list the artifacts
+CMD [ "find", "/artifacts", "-type", "f" ]

--- a/buildx/Dockerfile.ol9
+++ b/buildx/Dockerfile.ol9
@@ -20,6 +20,7 @@ ARG DISTRO_NAME="oraclelinux"
 ARG DISTRO_VERSION="9"
 ARG DISTRO_SHORT_NAME="ol9"
 ARG PROXY_ROOT_CA="DUMMY.pem"
+ARG CONFIG_ARGS=""
 
 # base0 is just the base image with the proxy root CA installed
 # note that if there is no proxy cert, a dummy value is used
@@ -117,10 +118,11 @@ RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAI
 
 
 FROM gitcloned AS builder
+ARG CONFIG_ARGS
 
 # build the project for tar package (/usr/local)
-RUN ./bootstrap.sh \
-    && ./configure \
+RUN ./bootstrap.sh --shallow-clone \
+    && ./configure $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install DESTDIR=/tar_build
 
@@ -135,7 +137,7 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
 
 # Build again the project for rpm package (/usr)
 RUN make distclean \
-    && ./configure --prefix=/usr \
+    && ./configure --prefix=/usr $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install DESTDIR=/rpm_build
 

--- a/buildx/Dockerfile.ol9
+++ b/buildx/Dockerfile.ol9
@@ -25,21 +25,24 @@ ARG PROXY_ROOT_CA="DUMMY.pem"
 # note that if there is no proxy cert, a dummy value is used
 FROM ${DISTRO_NAME}:${DISTRO_VERSION} AS base0
 ARG PROXY_ROOT_CA
-COPY ${PROXY_ROOT_CA} /usr/local/share/ca-certificates/${PROXY_ROOT_CA}
-RUN dnf update -y && dnf install -y ca-certificates
+
+COPY ${PROXY_ROOT_CA} /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust extract
 
 FROM base0 AS base
 ARG DISTRO_SHORT_NAME
 
 # ol9_codeready_builder is required to install autoconf-archive
 
-RUN OL=$(rpm --eval "%{dist}" | sed s/.e/o/) EL=$(rpm --eval "%{dist}" | sed s/.//) \
+RUN OL=ol$(rpm --eval "%{rhel}") EL=el$(rpm --eval "%{rhel}") \
+    && dnf update -y \
     && dnf --enablerepo=${OL}_codeready_builder install -y \
     oraclelinux-developer-release-${EL} \
     epel-release \
     gcc \
     make \
     flex \
+    bison \
     automake \
     autoconf \
     autoconf-archive \

--- a/buildx/Dockerfile.ol9
+++ b/buildx/Dockerfile.ol9
@@ -32,6 +32,7 @@ RUN update-ca-trust extract
 
 FROM base0 AS base
 ARG DISTRO_SHORT_NAME
+ENV TZ=UTC
 
 # ol9_codeready_builder is required to install autoconf-archive
 

--- a/buildx/Dockerfile.ubuntu2004
+++ b/buildx/Dockerfile.ubuntu2004
@@ -1,4 +1,4 @@
-# Dockerfile for building pkcs11-tools for Ubuntu 24.04
+# Dockerfile for building pkcs11-tools for Ubuntu 22.04
 #
 # Copyright (c) 2025 Mastercard
 
@@ -17,8 +17,8 @@
 ARG REPO_URL="https://github.com/Mastercard/pkcs11-tools"
 ARG REPO_COMMIT_OR_TAG="HEAD"
 ARG DISTRO_NAME="ubuntu"
-ARG DISTRO_VERSION="24.04"
-ARG DISTRO_SHORT_NAME="ubuntu2404"
+ARG DISTRO_VERSION="20.04"
+ARG DISTRO_SHORT_NAME="ubuntu2004"
 ARG PROXY_ROOT_CA="DUMMY.pem"
 ARG CONFIG_ARGS=""
 
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y \
 
 FROM base AS gitcloned
 ARG REPO_URL
-ARG REPO_COMMIT_OR_TAG
+ARG REPO_COMMIT_OR_TAG="HEAD"
 
 # The meta directory is used to store the version and maintainer information
 # for the DEB package
@@ -86,7 +86,6 @@ RUN PKG_VERSION=$(git describe --tags | sed -E 's/^v([^\-]+)(-.*)?$/\1/' ) \
     && echo "PKG_RELEASE=\"$PKG_RELEASE\"" >> /meta/env \
     && echo "PKG_GITCOMMIT=\"$PKG_GITCOMMIT\"" >> /meta/env
 
-
 # Retrieve the maintainer from git
 RUN PKG_MAINTAINER=$(git log -1 --pretty=format:'%an <%ae>') \
     && echo "PKG_MAINTAINER=\"$PKG_MAINTAINER\"" >> /meta/env
@@ -109,12 +108,13 @@ RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAI
 
 
 FROM gitcloned AS builder
+ARG CONFIG_ARGS
 
 # Build the project for tar package (/usr/local)
 RUN ./bootstrap.sh --shallow-clone \
     && ./configure $CONFIG_ARGS \
     && make -j $(nproc)\
-    && make install DESTDIR=/tar_build
+    && make install-strip DESTDIR=/tar_build
 
 # Install documentation
 RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
@@ -129,7 +129,7 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
 RUN make distclean \
     && ./configure --prefix=/usr --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) $CONFIG_ARGS \
     && make -j $(nproc) \
-    && make install DESTDIR=/deb_build
+    && make install-strip DESTDIR=/deb_build
 
 # Install documentation
 RUN mkdir -p /deb_build/usr/share/doc/pkcs11-tools \
@@ -166,14 +166,13 @@ RUN . /meta/env \
     && echo "Section: utils" >> DEBIAN/control \
     && echo "Priority: optional" >> DEBIAN/control \
     && echo "Architecture: $PKG_ARCH" >> DEBIAN/control \
-    && echo "Depends: libc6, libssl3" >> DEBIAN/control \
+    && echo "Depends: libc6, libssl1.1" >> DEBIAN/control \
     && echo "Maintainer: $PKG_MAINTAINER" >> DEBIAN/control \
     && echo "Description: a set of tools for manipulation of PKCS#11 objects" >> DEBIAN/control
 
-
 # Build the .deb package
 RUN . /meta/env \
-    && dpkg-deb --build /deb_build /artifacts/libpkcs11shim-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.deb
+    && dpkg-deb --build /deb_build /artifacts/pkcs11-tools-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.deb
 
 # Final command to list the artifacts
 CMD [ "find", "/artifacts", "-type", "f" ]

--- a/buildx/Dockerfile.ubuntu2204
+++ b/buildx/Dockerfile.ubuntu2204
@@ -20,6 +20,7 @@ ARG DISTRO_NAME="ubuntu"
 ARG DISTRO_VERSION="22.04"
 ARG DISTRO_SHORT_NAME="ubuntu2204"
 ARG PROXY_ROOT_CA="DUMMY.pem"
+ARG CONFIG_ARGS=""
 
 # base0 is just the base image with the proxy root CA installed
 # note that if there is no proxy cert, a dummy value is used
@@ -93,7 +94,7 @@ RUN PKG_MAINTAINER=$(git log -1 --pretty=format:'%an <%ae>') \
 # moreover, any occurrence of '`' should be removed to avoid issues with
 # the shell
 RUN PKG_DESCRIPTION=$(cat README.md \
-    | awk '/## Introduction/{flag=1} /## Download/{flag=0} flag' \
+    | awk '/# PKCS\\#11 tools/{flag=1} /Some features:/{flag=0} flag' \
     | sed '/^##.*/d' \
     | pandoc -f markdown -t plain \
     | sed '/^[[:space:]]*$/d' \
@@ -105,10 +106,11 @@ RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAI
 
 
 FROM gitcloned AS builder
+ARG CONFIG_ARGS
 
 # Build the project for tar package (/usr/local)
-RUN ./bootstrap.sh \
-    && ./configure \
+RUN ./bootstrap.sh --shallow-clone \
+    && ./configure $CONFIG_ARGS \
     && make -j $(nproc)\
     && make install-strip DESTDIR=/tar_build
 
@@ -123,7 +125,7 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
 
 # Build again the project for deb package (/usr)
 RUN make distclean \
-    && ./configure --prefix=/usr --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
+    && ./configure --prefix=/usr --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install-strip DESTDIR=/deb_build
 

--- a/buildx/Dockerfile.ubuntu2204
+++ b/buildx/Dockerfile.ubuntu2204
@@ -30,6 +30,8 @@ COPY ${PROXY_ROOT_CA} /usr/local/share/ca-certificates/${PROXY_ROOT_CA}
 RUN apt-get update && apt-get install -y ca-certificates
 
 FROM base0 AS base
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
 
 # Install required packages for building the project
 RUN apt-get update && apt-get install -y \

--- a/buildx/Dockerfile.ubuntu2204
+++ b/buildx/Dockerfile.ubuntu2204
@@ -1,0 +1,175 @@
+# Dockerfile for building pkcs11-tools for Ubuntu 22.04
+#
+# Copyright (c) 2025 Mastercard
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG REPO_URL="https://github.com/Mastercard/pkcs11-tools"
+ARG REPO_COMMIT_OR_TAG="HEAD"
+ARG DISTRO_NAME="ubuntu"
+ARG DISTRO_VERSION="22.04"
+ARG DISTRO_SHORT_NAME="ubuntu2204"
+ARG PROXY_ROOT_CA="DUMMY.pem"
+
+# base0 is just the base image with the proxy root CA installed
+# note that if there is no proxy cert, a dummy value is used
+FROM ${DISTRO_NAME}:${DISTRO_VERSION} AS base0
+ARG PROXY_ROOT_CA
+COPY ${PROXY_ROOT_CA} /usr/local/share/ca-certificates/${PROXY_ROOT_CA}
+RUN apt-get update && apt-get install -y ca-certificates
+
+FROM base0 AS base
+
+# Install required packages for building the project
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    autoconf \
+    autoconf-archive \
+    automake \
+    libtool \
+    pkg-config \
+    make \
+    perl \
+    libssl-dev \
+    gawk \
+    git \
+    tar \
+    gzip \
+    dpkg-dev \
+    pandoc \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM base AS gitcloned
+ARG REPO_URL
+ARG REPO_COMMIT_OR_TAG="HEAD"
+
+# The meta directory is used to store the version and maintainer information
+# for the DEB package
+RUN mkdir -p /meta
+
+# Clone the repository
+WORKDIR /src
+RUN git clone $REPO_URL .
+RUN git checkout $REPO_COMMIT_OR_TAG
+
+# Copy the include files for the nCipher and Luna HSMs if they are present
+RUN mkdir -p include/cryptoki
+COPY ./include/cryptoki/ncipher.* ./include/cryptoki/luna.* include/cryptoki/
+
+# Retrieve information for building DEB package later
+
+# Retrieve the architecture
+RUN PKG_ARCH=$(dpkg --print-architecture) \
+    && echo "PKG_ARCH=\"$PKG_ARCH\"" >> /meta/env
+
+# Retrieve version information from git
+# If the version is a tag, set PKG_GITSUFFIX to the tag, or to '~<commit>' if the tag is not the last commit
+RUN PKG_VERSION=$(git describe --tags | sed -E 's/^v([^\-]+)(-.*)?$/\1/' ) \
+    PKG_RELEASE=$(git describe --tags | sed -E 's/^v([^\-]+)(-.*)?$/\2/; s/^-//; s/^$/0/; s/-(.*)//' ) \
+    PKG_GITCOMMIT=$(git rev-parse --short HEAD) \
+    PKG_GITSUFFIX=$(git describe --tags | sed -E 's/^v([^\-]+)(-.*)?$/\2/;s/-([0-9]*)-g(.*)/~\2/') \
+    && echo "PKG_GITSUFFIX=\"$PKG_GITSUFFIX\"" >> /meta/env \
+    && echo "PKG_VERSION=\"$PKG_VERSION\"" >> /meta/env \
+    && echo "PKG_RELEASE=\"$PKG_RELEASE\"" >> /meta/env \
+    && echo "PKG_GITCOMMIT=\"$PKG_GITCOMMIT\"" >> /meta/env
+
+# Retrieve the maintainer from git
+RUN PKG_MAINTAINER=$(git log -1 --pretty=format:'%an <%ae>') \
+    && echo "PKG_MAINTAINER=\"$PKG_MAINTAINER\"" >> /meta/env
+
+# Retrieve description from README.md
+# This is a bit more complex as we need to strip out the first heading
+# and the first line of the second heading
+# moreover, any occurrence of '`' should be removed to avoid issues with
+# the shell
+RUN PKG_DESCRIPTION=$(cat README.md \
+    | awk '/## Introduction/{flag=1} /## Download/{flag=0} flag' \
+    | sed '/^##.*/d' \
+    | pandoc -f markdown -t plain \
+    | sed '/^[[:space:]]*$/d' \
+    | sed '1!s/^/ /')\
+    && echo "PKG_DESCRIPTION=\"$PKG_DESCRIPTION\"" >> /meta/env
+
+
+RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAINER PKG_ARCH" >> /meta/env
+
+
+FROM gitcloned AS builder
+
+# Build the project for tar package (/usr/local)
+RUN ./bootstrap.sh \
+    && ./configure \
+    && make -j $(nproc)\
+    && make install-strip DESTDIR=/tar_build
+
+# Install documentation
+RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
+    && install -m 644 -t /tar_build/usr/local/share/doc/pkcs11-tools \
+    README.md CHANGELOG.md COPYING \
+    docs/INSTALL.md \
+    docs/MANUAL.md \
+    docs/TPLICENSES.md \
+    docs/CONTRIBUTING.md
+
+# Build again the project for deb package (/usr)
+RUN make distclean \
+    && ./configure --prefix=/usr --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
+    && make -j $(nproc) \
+    && make install-strip DESTDIR=/deb_build
+
+# Install documentation
+RUN mkdir -p /deb_build/usr/share/doc/pkcs11-tools \
+    && install -m 644 -t /deb_build/usr/share/doc/pkcs11-tools \
+    README.md CHANGELOG.md COPYING \
+    docs/INSTALL.md \
+    docs/MANUAL.md \
+    docs/TPLICENSES.md \
+    docs/CONTRIBUTING.md
+
+
+# Final stage
+FROM builder AS final
+ARG DISTRO_SHORT_NAME
+
+RUN mkdir -p /artifacts
+
+# build the .tar.gz file
+WORKDIR /tar_build
+RUN . /meta/env && tar -czf /artifacts/pkcs11-tools-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.tar.gz usr
+
+# build the deb package
+WORKDIR /deb_build
+RUN mkdir -p DEBIAN /artifacts
+
+# Create control file for the package
+RUN . /meta/env \
+    && echo "Package: pkcs11-tools" > DEBIAN/control \
+    && echo "Version: $PKG_VERSION$PKG_GITSUFFIX" >> DEBIAN/control \
+    && echo "License: Apache 2.0" >> DEBIAN/control \
+    && echo "Homepage: $REPO_URL" >> DEBIAN/control \
+    && echo "X-Vcs-Git: $REPO_URL" >> DEBIAN/control \
+    && echo "X-Git-Commit: $PKG_GITCOMMIT" >> DEBIAN/control \
+    && echo "Section: utils" >> DEBIAN/control \
+    && echo "Priority: optional" >> DEBIAN/control \
+    && echo "Architecture: $PKG_ARCH" >> DEBIAN/control \
+    && echo "Depends: libc6, libssl3" >> DEBIAN/control \
+    && echo "Maintainer: $PKG_MAINTAINER" >> DEBIAN/control \
+    && echo "Description: a set of tools for manipulation of PKCS#11 objects" >> DEBIAN/control
+
+# Build the .deb package
+RUN . /meta/env \
+    && dpkg-deb --build /deb_build /artifacts/pkcs11-tools-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.deb
+
+# Final command to list the artifacts
+CMD [ "find", "/artifacts", "-type", "f" ]
+

--- a/buildx/Dockerfile.ubuntu2404
+++ b/buildx/Dockerfile.ubuntu2404
@@ -1,0 +1,177 @@
+# Dockerfile for building pkcs11-tools for Ubuntu 24.04
+#
+# Copyright (c) 2025 Mastercard
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG REPO_URL="https://github.com/Mastercard/pkcs11-tools"
+ARG REPO_COMMIT_OR_TAG="HEAD"
+ARG DISTRO_NAME="ubuntu"
+ARG DISTRO_VERSION="24.04"
+ARG DISTRO_SHORT_NAME="ubuntu2404"
+ARG PROXY_ROOT_CA="DUMMY.pem"
+
+# base0 is just the base image with the proxy root CA installed
+# note that if there is no proxy cert, a dummy value is used
+FROM ${DISTRO_NAME}:${DISTRO_VERSION} AS base0
+ARG PROXY_ROOT_CA
+COPY ${PROXY_ROOT_CA} /usr/local/share/ca-certificates/${PROXY_ROOT_CA}
+RUN apt-get update && apt-get install -y ca-certificates
+
+FROM base0 AS base
+
+# Install required packages for building the project
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    autoconf \
+    autoconf-archive \
+    automake \
+    libtool \
+    pkg-config \
+    make \
+    perl \
+    libssl-dev \
+    gawk \
+    git \
+    tar \
+    gzip \
+    dpkg-dev \
+    pandoc \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM base AS gitcloned
+ARG REPO_URL
+ARG REPO_COMMIT_OR_TAG="HEAD"
+
+# The meta directory is used to store the version and maintainer information
+# for the DEB package
+RUN mkdir -p /meta
+
+# Clone the repository
+WORKDIR /src
+RUN git clone $REPO_URL .
+RUN git checkout $REPO_COMMIT_OR_TAG
+
+# Copy the include files for the nCipher and Luna HSMs if they are present
+RUN mkdir -p include/cryptoki
+COPY ./include/cryptoki/ncipher.* ./include/cryptoki/luna.* include/cryptoki/
+
+# Retrieve information for building DEB package later
+
+# Retrieve the architecture
+RUN PKG_ARCH=$(dpkg --print-architecture) \
+    && echo "PKG_ARCH=\"$PKG_ARCH\"" >> /meta/env
+
+# Retrieve version information from git
+# If the version is a tag, set PKG_GITSUFFIX to the tag, or to '~<commit>' if the tag is not the last commit
+RUN PKG_VERSION=$(git describe --tags | sed -E 's/^v([^\-]+)(-.*)?$/\1/' ) \
+    PKG_RELEASE=$(git describe --tags | sed -E 's/^v([^\-]+)(-.*)?$/\2/; s/^-//; s/^$/0/; s/-(.*)//' ) \
+    PKG_GITCOMMIT=$(git rev-parse --short HEAD) \
+    PKG_GITSUFFIX=$(git describe --tags | sed -E 's/^v([^\-]+)(-.*)?$/\2/;s/-([0-9]*)-g(.*)/~\2/') \
+    && echo "PKG_GITSUFFIX=\"$PKG_GITSUFFIX\"" >> /meta/env \
+    && echo "PKG_VERSION=\"$PKG_VERSION\"" >> /meta/env \
+    && echo "PKG_RELEASE=\"$PKG_RELEASE\"" >> /meta/env \
+    && echo "PKG_GITCOMMIT=\"$PKG_GITCOMMIT\"" >> /meta/env
+
+
+# Retrieve the maintainer from git
+RUN PKG_MAINTAINER=$(git log -1 --pretty=format:'%an <%ae>') \
+    && echo "PKG_MAINTAINER=\"$PKG_MAINTAINER\"" >> /meta/env
+
+# Retrieve description from README.md
+# This is a bit more complex as we need to strip out the first heading
+# and the first line of the second heading
+# moreover, any occurrence of '`' should be removed to avoid issues with
+# the shell
+RUN PKG_DESCRIPTION=$(cat README.md \
+    | awk '/## Introduction/{flag=1} /## Download/{flag=0} flag' \
+    | sed '/^##.*/d' \
+    | pandoc -f markdown -t plain \
+    | sed '/^[[:space:]]*$/d' \
+    | sed '1!s/^/ /')\
+    && echo "PKG_DESCRIPTION=\"$PKG_DESCRIPTION\"" >> /meta/env
+
+
+RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAINER PKG_ARCH" >> /meta/env
+
+
+FROM gitcloned AS builder
+
+# Build the project for tar package (/usr/local)
+RUN ./bootstrap.sh \
+    && ./configure \
+    && make -j $(nproc)\
+    && make install DESTDIR=/tar_build
+
+# Install documentation
+RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
+    && install -m 644 -t /tar_build/usr/local/share/doc/pkcs11-tools \
+    README.md CHANGELOG.md COPYING \
+    docs/INSTALL.md \
+    docs/MANUAL.md \
+    docs/TPLICENSES.md \
+    docs/CONTRIBUTING.md
+
+# Build again the project for deb package (/usr)
+RUN make distclean \
+    && ./configure --prefix=/usr --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
+    && make -j $(nproc) \
+    && make install DESTDIR=/deb_build
+
+# Install documentation
+RUN mkdir -p /deb_build/usr/share/doc/pkcs11-tools \
+    && install -m 644 -t /deb_build/usr/share/doc/pkcs11-tools \
+    README.md CHANGELOG.md COPYING \
+    docs/INSTALL.md \
+    docs/MANUAL.md \
+    docs/TPLICENSES.md \
+    docs/CONTRIBUTING.md
+
+
+# Final stage
+FROM builder AS final
+ARG DISTRO_SHORT_NAME
+
+RUN mkdir -p /artifacts
+
+# build the .tar.gz file
+WORKDIR /tar_build
+RUN . /meta/env && tar -czf /artifacts/pkcs11-tools-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.tar.gz usr
+
+# build the deb package
+WORKDIR /deb_build
+RUN mkdir -p DEBIAN /artifacts
+
+# Create control file for the package
+RUN . /meta/env \
+    && echo "Package: pkcs11-tools" > DEBIAN/control \
+    && echo "Version: $PKG_VERSION$PKG_GITSUFFIX" >> DEBIAN/control \
+    && echo "License: Apache 2.0" >> DEBIAN/control \
+    && echo "Homepage: $REPO_URL" >> DEBIAN/control \
+    && echo "X-Vcs-Git: $REPO_URL" >> DEBIAN/control \
+    && echo "X-Git-Commit: $PKG_GITCOMMIT" >> DEBIAN/control \
+    && echo "Section: utils" >> DEBIAN/control \
+    && echo "Priority: optional" >> DEBIAN/control \
+    && echo "Architecture: $PKG_ARCH" >> DEBIAN/control \
+    && echo "Depends: libc6, libssl3" >> DEBIAN/control \
+    && echo "Maintainer: $PKG_MAINTAINER" >> DEBIAN/control \
+    && echo "Description: a set of tools for manipulation of PKCS#11 objects" >> DEBIAN/control
+
+
+# Build the .deb package
+RUN . /meta/env \
+    && dpkg-deb --build /deb_build /artifacts/libpkcs11shim-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.deb
+
+# Final command to list the artifacts
+CMD [ "find", "/artifacts", "-type", "f" ]
+

--- a/buildx/Dockerfile.ubuntu2404
+++ b/buildx/Dockerfile.ubuntu2404
@@ -20,6 +20,7 @@ ARG DISTRO_NAME="ubuntu"
 ARG DISTRO_VERSION="24.04"
 ARG DISTRO_SHORT_NAME="ubuntu2404"
 ARG PROXY_ROOT_CA="DUMMY.pem"
+ARG CONFIG_ARGS=""
 
 # base0 is just the base image with the proxy root CA installed
 # note that if there is no proxy cert, a dummy value is used
@@ -51,7 +52,7 @@ RUN apt-get update && apt-get install -y \
 
 FROM base AS gitcloned
 ARG REPO_URL
-ARG REPO_COMMIT_OR_TAG="HEAD"
+ARG REPO_COMMIT_OR_TAG
 
 # The meta directory is used to store the version and maintainer information
 # for the DEB package
@@ -94,7 +95,7 @@ RUN PKG_MAINTAINER=$(git log -1 --pretty=format:'%an <%ae>') \
 # moreover, any occurrence of '`' should be removed to avoid issues with
 # the shell
 RUN PKG_DESCRIPTION=$(cat README.md \
-    | awk '/## Introduction/{flag=1} /## Download/{flag=0} flag' \
+    | awk '/# PKCS\\#11 tools/{flag=1} /Some features:/{flag=0} flag' \
     | sed '/^##.*/d' \
     | pandoc -f markdown -t plain \
     | sed '/^[[:space:]]*$/d' \
@@ -108,8 +109,8 @@ RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_MAINTAI
 FROM gitcloned AS builder
 
 # Build the project for tar package (/usr/local)
-RUN ./bootstrap.sh \
-    && ./configure \
+RUN ./bootstrap.sh --shallow-clone \
+    && ./configure $CONFIG_ARGS \
     && make -j $(nproc)\
     && make install DESTDIR=/tar_build
 
@@ -124,7 +125,7 @@ RUN mkdir -p /tar_build/usr/local/share/doc/pkcs11-tools \
 
 # Build again the project for deb package (/usr)
 RUN make distclean \
-    && ./configure --prefix=/usr --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
+    && ./configure --prefix=/usr --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) $CONFIG_ARGS \
     && make -j $(nproc) \
     && make install DESTDIR=/deb_build
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,11 +1,62 @@
-# Installation instructions
-## Important Notes
+# Installation
+
+## Using pre-built binaries
+Pre-built binaries are available for download from the release page. This is the simplest option, but you may be lacking the latest features.
+
+## Using Docker on Linux
+Provided that Docker is deployed on your system, you can build the toolkit using the `buildx.sh` script, which is located in the root directory of the project. This script automates the process of building the toolkit for various distributions and architectures. For each target platform, both a tarball and a distribution-specific package (`.deb`, `.rpm`, `.apk`) are built.
+
+To build the toolkit using Docker for your architecture, you can use the following command (in this example, we are building for Ubuntu 24.04):
+```bash
+$ ./buildx.sh ubuntu2404
+```
+
+You can specify more than one target distribution at once, for example:
+```bash
+$ ./buildx.sh ol9 ubuntu2404 deb12
+```
+
+Provided that your environment supports multiple architectures (using `qemu`), you can cross-compile the toolkit. For each target platform, you can specify the architecture. Note that `all` means to build for all available architectures, i.e. `x86_64` and `aarch64` in this occurence. For example:
+```bash
+$ ./buildx.sh ol9/amd64 ubuntu2404/arm64 deb12/all
+```
+
+`buildx.sh` supports parallel building, and comes with a number of options to specify the target distribution, the target architecture, additional `configure` options, additional root CA in case of corporate proxy, and so on. You can see the help message by running:
+```bash
+$ ./buildx.sh --help
+```
+
+### supported distributions
+The following distributions are supported by the `buildx.sh` script:
+
+| Distribution | Distribution short name (to use with `buildx.sh`) |
+|--------------|---------------------------------------------------|
+| Oracle Linux 9 | `ol9` |
+| Oracle Linux 8 | `ol8` |
+| Oracle Linux 7 | `ol7` |
+| Debian 12 (Bookworm) | `deb12` |
+| Ubuntu 24.04 (Lunar Lobster) | `ubuntu2404` |
+| Ubuntu 22.04 (Jammy) | `ubuntu2204` |
+| Alpine Linux 3.21 | `alpine321` |
+| Amazon Linux 2023 | `amzn2023` |
+
+### Docker buildx for AWS CloudHSM support
+To build the toolkit with AWS CloudHSM support using Docker buildx, you can use the following command:
+```bash
+$ ./buildx.sh --config-args="--with-awscloudhsm"  amzn2023 
+```
+
+__Note that support for AWS CloudHSM is disabling a few features in the toolkit, and should be used only if you plan to use the toolkit with AWS CloudHSM. The toolkit can be built without AWS CloudHSM support, which will enable all features of the toolkit, but will not work well with AWS CloudHSM.__
+
+
+## Building from source
+### Important Notes
  * While a prefix can be specified at configuration time, the toolkit utility make no use of any hardcoded path.  Using `--prefix=$PWD`will deploy the binaries into a `bin` subdir, relative to the current directory.
  if that option is omitted, the default is to deploy in `/usr/local`, when invoking `make install`. In which case, you will need to be a `root` user when `make install` (or to use `su` or `sudo`) .
  * OpenSSL v1.1.1e or above is required to compile the toolkit. Please refer to [OpenSSL 1.1.1](#openssl-111) for details how to deploy it on your system.
  * Windows 64 bits is currently not supported. See [Note on 64 bits executables](#note-on-64-bits-executables) for more information.
 
-## Pre-requisites
+### Pre-requisites
 In order to build the project from scratch, you will need
  - a C compiler (tested with `gcc`, `clang`, `xlc` on `AIX`), and make utility (tested with GNU and BSD `make`)
    If your host is Debian-based (e.g. Ubuntu), you can execute the following command:
@@ -31,7 +82,7 @@ In order to build the project from scratch, you will need
  - a connection to Internet (to fetch `gnulib` and the pkcs11 headers)
 
 
-### OpenSSL 1.1.1
+#### OpenSSL 1.1.1
 The vast majority of recent distros (FreeBSD and Linux) have OpenSSL 1.1.1e+ by default.
 
 If your platform does not have it, proceed as follows:
@@ -70,8 +121,8 @@ If your platform does not have it, proceed as follows:
     
 Note: Usually, building OpenSSL requires `zlib` development package to be present on your system. This option is not useful to `pkcs11-tools`. However, if you wish to have it (in case you also want to use that version of OpenSSL for other purposes), change the `no-zlib` option by `zlib`.
 
-## Installation
-### Bootstrapping the environment from GitHub
+### Installation
+#### Bootstrapping the environment from GitHub
 In order to create the autotools and libtool environment, and before being able to execute the `configure`script, you must execute these steps:
 ```bash
 $ git clone https://github.com/Mastercard/pkcs11-tools.git
@@ -230,22 +281,22 @@ By default, AWS CloudHSM support is disabled, as it removes some functionality f
 $ ./configure --with-awscloudhsm
 ```
 
-## Packaging
-### all platforms
+### Packaging
+#### all platforms
 To build a generic binary distribution tarball (all platforms):
 ```bash
 $ ./configure [...] --prefix=$PWD
 $ make dist-bin
 ```
 
-### Solaris pkg
+#### Solaris pkg
 To build solaris package:
 ```bash
 $ ./configure [...] --prefix=$PWD
 $ make dist-solaris
 ```
 
-### RPM
+#### RPM
 To build an RPM package:
 (this assumes that `rpmbuild` is installed and properly configured for the user; it also assumes that OpenSSL 1.1.1 is the default on your platform)
 ```bash

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -35,8 +35,9 @@ The following distributions are supported by the `buildx.sh` script:
 | Oracle Linux 8 | `ol8` |
 | Oracle Linux 7 | `ol7` |
 | Debian 12 (Bookworm) | `deb12` |
-| Ubuntu 24.04 (Lunar Lobster) | `ubuntu2404` |
-| Ubuntu 22.04 (Jammy) | `ubuntu2204` |
+| Ubuntu 24.04 (Noble Numbat) | `ubuntu2404` |
+| Ubuntu 22.04 (Jammy Jellyfish) | `ubuntu2204` |
+| Ubuntu 20.04 (Focal Fossa) | `ubuntu2004` |
 | Alpine Linux 3.21 | `alpine321` |
 | Amazon Linux 2023 | `amzn2023` |
 

--- a/lib/pkcs11_kcv.c
+++ b/lib/pkcs11_kcv.c
@@ -91,9 +91,9 @@ void pkcs11_display_kcv( pkcs11Context *p11Context, char *label, unsigned hmacda
 					    _ATTR(CKA_KEY_TYPE),
 					    _ATTR(CKA_ID),
 					    _ATTR(CKA_LABEL),
-						_ATTR(CKA_CHECK_VALUE),
-						_ATTR(CKA_SIGN),
-						_ATTR(CKA_ENCRYPT),
+					    _ATTR(CKA_CHECK_VALUE),
+					    _ATTR(CKA_SIGN),
+					    _ATTR(CKA_ENCRYPT),
 					    _ATTR_END);
 
 		if( attrs!=NULL) {
@@ -157,214 +157,217 @@ void pkcs11_display_kcv( pkcs11Context *p11Context, char *label, unsigned hmacda
 			
 			/* if we ask for KCV  explicitely */
 			if(has_check_value && algo == kcv) {
-				// if we have a check value, we just display it
-				max_num_bytes = num_bytes = processed_len = MIN(a_check_value->ulValueLen, sizeof(processed));
-				keytypestr = "CKA_CHECK_VALUE";
-				memcpy(processed, a_check_value->pValue, processed_len);
+			    // if we have a check value, we just display it
+			    max_num_bytes = num_bytes = processed_len = MIN(a_check_value->ulValueLen, sizeof(processed));
+			    keytypestr = "CKA_CHECK_VALUE";
+			    memcpy(processed, a_check_value->pValue, processed_len);
 			} else {
-				switch( *((CK_KEY_TYPE *)a_keytype->pValue)) {
-				case CKK_DES:
-					cleartext_len = 8L;
-					processed_len = 8L;
-					max_num_bytes = 8;
+			    switch( *((CK_KEY_TYPE *)a_keytype->pValue)) {
+			    case CKK_DES:
+				cleartext_len = 8L;
+				processed_len = 8L;
+				max_num_bytes = 8;
 					
-					switch(algo) {
-					case legacy:
-					mechanism = &des_ecb;
-					whattodo=encrypt;
-					keytypestr = "DES, single length, ECB";
-					break;
+				switch(algo) {
+				case legacy:
+				    mechanism = &des_ecb;
+				    whattodo=encrypt;
+				    keytypestr = "DES, single length, ECB";
+				    break;
 
-					case mac:
-					mechanism = &des_mac;
-					whattodo=sign;
-					keytypestr = "DES, single length, MAC/FIPS PUB 113";
-					break;
-
-					default:
-					/* unsupported, we just break, no mechanism defined */
-					}
-					break;
-
-				case CKK_DES2:
-					is_des2 = true;
-					/* no break here */
-					
-				case CKK_DES3:
-					cleartext_len = 8L;
-					processed_len = 8L;
-
-					switch(algo) {
-					case legacy:
-					mechanism = &des3_ecb;
-					whattodo=encrypt;
-					max_num_bytes = 8;
-					keytypestr = is_des2 ? "3DES, double length, ECB" : "3DES, triple length, ECB";
-					break;
-
-					case mac:
-					mechanism = &des3_mac;
-					whattodo=sign;
-					max_num_bytes = 8;
-					keytypestr = is_des2 ? "3DES, double length, MAC/FIPS PUB 113" : "3DES, triple length, MAC/FIPS PUB 113";
-					break;
-
-					case cmac:
-					mechanism = &des3_cmac;
-					whattodo=sign;
-					max_num_bytes = 4;
-					keytypestr = is_des2 ? "3DES, double length, CMAC/RFC4493" : "3DES, triple length, CMAC/RFC4493";
-					break;
-
-					default:
-					/* unsupported, we just break, no mechanism defined */
-					}			    
-					break;
-
-
-				case CKK_AES:
-					cleartext_len = 16L;
-					processed_len = 16L;
-
-					switch(algo) {
-					case legacy:
-					mechanism = &aes_ecb;
-					whattodo=encrypt;
-					max_num_bytes = 16;
-					keytypestr = "AES, ECB";
-					break;
-
-					case mac:
-					mechanism = &aes_mac;
-					whattodo=sign;
-					max_num_bytes = 16;
-					keytypestr = "AES, MAC/FIPS PUB 113";
-					break;
-
-					case cmac:
-					mechanism = &aes_cmac;
-					whattodo=sign;
-					max_num_bytes = 8;
-					keytypestr = "AES, CMAC/RFC4493";
-					break;
-
-					case aes_xcbc_mac:
-					mechanism = &m_aes_xcbc_mac;
-					whattodo=sign;
-					max_num_bytes = 16;
-					keytypestr = "AES, XCBC-MAC/RFC3566";
-					break;
-
-					case aes_xcbc_mac_96:
-					mechanism = &m_aes_xcbc_mac_96;
-					whattodo=sign;
-					max_num_bytes = 12;
-					keytypestr = "AES, XCBC-MAC-96/RFC3566";
-					break;
-
-					default:
-					/* unsupported, we just break, no mechanism defined */
-					}			    
-					break;
-
-				case CKK_SHA_1_HMAC:
-					mechanism = &sha1_hmac;
-					cleartext_len = hmacdatasize;
-					processed_len = 20L;
-					keytypestr = "HMAC/SHA1";
-					whattodo=sign;
-					max_num_bytes = 20;
-					break;
-
-				case CKK_SHA224_HMAC:
-					mechanism = &sha224_hmac;
-					cleartext_len = hmacdatasize;
-					processed_len = 28L;
-					keytypestr = "HMAC/SHA244";
-					whattodo=sign;
-					max_num_bytes = 28;
-					break;
-
-				case CKK_SHA256_HMAC:
-				case CKK_GENERIC_SECRET:
-					mechanism = &sha256_hmac;
-					cleartext_len = hmacdatasize;
-					processed_len = 32L;
-					keytypestr = "HMAC/SHA256";
-					whattodo=sign;
-					max_num_bytes = 32;
-					break;
-
-				case CKK_SHA384_HMAC:
-					mechanism = &sha384_hmac;
-					cleartext_len = hmacdatasize;
-					processed_len = 48L;
-					keytypestr = "HMAC/SHA384";
-					whattodo=sign;
-					max_num_bytes = 48;
-					break;
-
-				case CKK_SHA512_HMAC:
-					mechanism = &sha512_hmac;
-					cleartext_len = hmacdatasize;
-					processed_len = 64L;
-					keytypestr = "HMAC/SHA512";
-					whattodo=sign;
-					max_num_bytes = 64;
-					break;
+				case mac:
+				    mechanism = &des_mac;
+				    whattodo=sign;
+				    keytypestr = "DES, single length, MAC/FIPS PUB 113";
+				    break;
 
 				default:
-					break;
+				    /* unsupported, we just break, no mechanism defined */
+				    break; /* break needed by some versions of GCC... */
 				}
+				break;
 
-				if(mechanism==NULL) {
-					fprintf(stderr, "Unsupported mechanism for key %s, skipping\n", buffer);
-					pkcs11_delete_attrlist(attrs);
-					continue;
-				}
+			    case CKK_DES2:
+				is_des2 = true;
+				/* no break here */
+					
+			    case CKK_DES3:
+				cleartext_len = 8L;
+				processed_len = 8L;
 
-				if(!can_sign && whattodo==sign) {
-					fprintf(stderr, "Key %s cannot sign, skipping\n", buffer);
-					pkcs11_delete_attrlist(attrs);
-					continue;
-				}
+				switch(algo) {
+				case legacy:
+				    mechanism = &des3_ecb;
+				    whattodo=encrypt;
+				    max_num_bytes = 8;
+				    keytypestr = is_des2 ? "3DES, double length, ECB" : "3DES, triple length, ECB";
+				    break;
 
-				if(!can_encrypt && whattodo==encrypt) {
-					fprintf(stderr, "Key %s cannot encrypt, skipping\n", buffer);
-					pkcs11_delete_attrlist(attrs);
-					continue;
-				}
+				case mac:
+				    mechanism = &des3_mac;
+				    whattodo=sign;
+				    max_num_bytes = 8;
+				    keytypestr = is_des2 ? "3DES, double length, MAC/FIPS PUB 113" : "3DES, triple length, MAC/FIPS PUB 113";
+				    break;
 
-				rv = whattodo == encrypt ?
-					p11Context->FunctionList.C_EncryptInit( p11Context->Session,
-										mechanism,
-										hndl_array[j]) :
-					p11Context->FunctionList.C_SignInit( p11Context->Session,
+				case cmac:
+				    mechanism = &des3_cmac;
+				    whattodo=sign;
+				    max_num_bytes = 4;
+				    keytypestr = is_des2 ? "3DES, double length, CMAC/RFC4493" : "3DES, triple length, CMAC/RFC4493";
+				    break;
+
+				default:
+				    /* unsupported, we just break, no mechanism defined */
+				    break; /* break needed by some versions of GCC... */
+				}			    
+				break;
+
+
+			    case CKK_AES:
+				cleartext_len = 16L;
+				processed_len = 16L;
+
+				switch(algo) {
+				case legacy:
+				    mechanism = &aes_ecb;
+				    whattodo=encrypt;
+				    max_num_bytes = 16;
+				    keytypestr = "AES, ECB";
+				    break;
+
+				case mac:
+				    mechanism = &aes_mac;
+				    whattodo=sign;
+				    max_num_bytes = 16;
+				    keytypestr = "AES, MAC/FIPS PUB 113";
+				    break;
+
+				case cmac:
+				    mechanism = &aes_cmac;
+				    whattodo=sign;
+				    max_num_bytes = 8;
+				    keytypestr = "AES, CMAC/RFC4493";
+				    break;
+
+				case aes_xcbc_mac:
+				    mechanism = &m_aes_xcbc_mac;
+				    whattodo=sign;
+				    max_num_bytes = 16;
+				    keytypestr = "AES, XCBC-MAC/RFC3566";
+				    break;
+
+				case aes_xcbc_mac_96:
+				    mechanism = &m_aes_xcbc_mac_96;
+				    whattodo=sign;
+				    max_num_bytes = 12;
+				    keytypestr = "AES, XCBC-MAC-96/RFC3566";
+				    break;
+
+				default:
+				    /* unsupported, we just break, no mechanism defined */
+				    break; 
+				}			    
+				break;
+
+			    case CKK_SHA_1_HMAC:
+				mechanism = &sha1_hmac;
+				cleartext_len = hmacdatasize;
+				processed_len = 20L;
+				keytypestr = "HMAC/SHA1";
+				whattodo=sign;
+				max_num_bytes = 20;
+				break;
+
+			    case CKK_SHA224_HMAC:
+				mechanism = &sha224_hmac;
+				cleartext_len = hmacdatasize;
+				processed_len = 28L;
+				keytypestr = "HMAC/SHA244";
+				whattodo=sign;
+				max_num_bytes = 28;
+				break;
+
+			    case CKK_SHA256_HMAC:
+			    case CKK_GENERIC_SECRET:
+				mechanism = &sha256_hmac;
+				cleartext_len = hmacdatasize;
+				processed_len = 32L;
+				keytypestr = "HMAC/SHA256";
+				whattodo=sign;
+				max_num_bytes = 32;
+				break;
+
+			    case CKK_SHA384_HMAC:
+				mechanism = &sha384_hmac;
+				cleartext_len = hmacdatasize;
+				processed_len = 48L;
+				keytypestr = "HMAC/SHA384";
+				whattodo=sign;
+				max_num_bytes = 48;
+				break;
+
+			    case CKK_SHA512_HMAC:
+				mechanism = &sha512_hmac;
+				cleartext_len = hmacdatasize;
+				processed_len = 64L;
+				keytypestr = "HMAC/SHA512";
+				whattodo=sign;
+				max_num_bytes = 64;
+				break;
+
+			    default:
+				break; /* break needed by some versions of GCC... */
+			    }
+
+			    if(mechanism==NULL) {
+				fprintf(stderr, "Unsupported mechanism for key %s, skipping\n", buffer);
+				pkcs11_delete_attrlist(attrs);
+				continue;
+			    }
+
+			    if(!can_sign && whattodo==sign) {
+				fprintf(stderr, "Key %s cannot sign, skipping\n", buffer);
+				pkcs11_delete_attrlist(attrs);
+				continue;
+			    }
+
+			    if(!can_encrypt && whattodo==encrypt) {
+				fprintf(stderr, "Key %s cannot encrypt, skipping\n", buffer);
+				pkcs11_delete_attrlist(attrs);
+				continue;
+			    }
+
+			    rv = whattodo == encrypt ?
+				p11Context->FunctionList.C_EncryptInit( p11Context->Session,
 									mechanism,
-									hndl_array[j]);
+									hndl_array[j]) :
+				p11Context->FunctionList.C_SignInit( p11Context->Session,
+								     mechanism,
+								     hndl_array[j]);
 
-				if(rv!=CKR_OK) {
-					pkcs11_error(rv, whattodo == encrypt ? "C_EncryptInit" : "C_SignInit");
-					pkcs11_delete_attrlist(attrs);
-					continue;
-				}
+			    if(rv!=CKR_OK) {
+				pkcs11_error(rv, whattodo == encrypt ? "C_EncryptInit" : "C_SignInit");
+				pkcs11_delete_attrlist(attrs);
+				continue;
+			    }
 
-				rv = whattodo == encrypt ?
-					p11Context->FunctionList.C_Encrypt ( p11Context->Session,
-									cleartext,
-									cleartext_len,
-									processed,
-									&processed_len	) :
-					p11Context->FunctionList.C_Sign ( p11Context->Session,
-									cleartext,
-									cleartext_len,
-									processed,
-									&processed_len );
-				if(rv!=CKR_OK) {
-					pkcs11_error(rv, whattodo == encrypt ? "C_Encrypt" : "C_Sign");
-					pkcs11_delete_attrlist(attrs);
-					continue;
-				}
+			    rv = whattodo == encrypt ?
+				p11Context->FunctionList.C_Encrypt ( p11Context->Session,
+								     cleartext,
+								     cleartext_len,
+								     processed,
+								     &processed_len	) :
+				p11Context->FunctionList.C_Sign ( p11Context->Session,
+								  cleartext,
+								  cleartext_len,
+								  processed,
+								  &processed_len );
+			    if(rv!=CKR_OK) {
+				pkcs11_error(rv, whattodo == encrypt ? "C_Encrypt" : "C_Sign");
+				pkcs11_delete_attrlist(attrs);
+				continue;
+			    }
 			}
 			
 			/* now, the display job */


### PR DESCRIPTION
This PR allows building the toolkit using `docker buildx`, for the following flavours:
 - Oracle Linux 7,8,9
 - Debian 12
 - Ubuntu 22.04 and 24.04
 - AlpineLinux 3.21
 - AmazonLinux 2023

It can launch builds in parallel, to accelerate production of builds. 
For each platform, a tarball and a target platform package are produced.
For now, the following architectures are supported:
 - x86_64  (amd64)
 - aarch64 (arm64)

The `buildx.sh` has options to support:
 - Enterprise proxy root CA install during building phase
 - Fetching from a different repo
 - Building a different branch,commit,tag than HEAD
 - Passing additional `configure` optional arguments or variables
 - Increasing verbosity during build


