### PR TITLE
docs: fix ECC capabilities table

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -271,7 +271,7 @@ additional capabilities printed:
 | `F^2m`       | Supports curves defined over power of 2 fields  |
 | `par`        | Supports custom parameters curves               |
 | `nam`        | Supports well-known named curves                |
-| `unc`        | Supports compressed points representation       |
+| `unc`        | Supports uncompressed points representation     |
 | `cmp`        | Supports compressed points representation       |
 
 Here is an example of `p11slotinfo` executed with SoftHSMv2:


### PR DESCRIPTION
Fixes the broken `pkcs11info` table rendering for ECC capabilities: https://github.com/Mastercard/pkcs11-tools/blob/master/docs/MANUAL.md#p11slotinfo

The f192a44 commit was the result of the automatic formatting by my editor but I included it as it fixes some minor stray spaces. Happy to drop the commit though :+1: 

---

* docs: reformat table alignment (f192a44)      

* docs: fix ECC capabilities table (6a5e4ba)
      
      Fix the ECC capabilities markdown table so it renders correctly.

