### PR TITLE
Fix Broken and Corrupted Links

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -7,12 +7,12 @@ the [PKCS\#11 standard](https://www.oasis-open.org/committees/tc_home.php?wg_abb
 important place in key management and operation, for various reasons:
 
 - Virtually all HSM and smart card vendors support this interface
-- Software libraries, such a [SoftHSM](https://www.opendnssec.org/softhsm/) supports
+- Software libraries, such a [SoftHSM](https://www.opendnssec.org/en/latest/softhsm/) supports
   it; [NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS) also exposes a PKCS\#11 interface, although
   it requires specific API calls to initialize
 - Java
   platforms ([IBM](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.security.component.80.doc/security-component/pkcs11implDocs/ibmpkcs11.html)
-  and [Oracle](https://docs.oracle.com/en/java/javase/11/security/pkcs11-reference-guide1.html)) both support, through
+  and [Oracle](https://docs.oracle.com/en/java/javase/11/security/pkcs11-reference-guide.html)) both support, through
   JCE providers, access to PKCS\#11-protected keys and certificates
 - It is also widely supported in many other languages and platforms (C++, Python, Rust, Ruby, ...)
 

--- a/lib/pkcs11_ll_win.c
+++ b/lib/pkcs11_ll_win.c
@@ -98,7 +98,7 @@ void pkcs11_ll_echo_on(void)
 
 void pkcs11_ll_clear_screen(void)
 {
-    /* the code below has been taken from http://support.microsoft.com/kb/99261 */
+    /* the code below has been taken from https://learn.microsoft.com/en-us/windows/console/clearing-the-screen */
 
     /* Standard error macro for reporting API errors */ 
 #define PERR(bSuccess, api){if(!(bSuccess)) printf("%s:Error %d from %s on line %d\n", __FILE__, GetLastError(), api, __LINE__);}

--- a/m4/ax_with_dmalloc.m4
+++ b/m4/ax_with_dmalloc.m4
@@ -9,7 +9,7 @@
 # DESCRIPTION
 #
 #   Let the user enable/disable support for the dmalloc library available
-#   from <http://www.dmalloc.org/>.
+#   from <http://www.dmalloc.com/>.
 #
 #   The macro adds the command-line flag "--with-dmalloc". Furthermore,
 #   "-IPREFIX/include" will be added to "$CPPFLAGS", "-LPREFIX/lib" to

--- a/src/win_applink.c
+++ b/src/win_applink.c
@@ -17,7 +17,7 @@
  */
 
 /* This glue code is needed under Windows,  */
-/* please refer to https://www.openssl.org/support/faq.html#PROG2  */
+/* please refer to https://docs.openssl.org/1.1.1/man3/OPENSSL_Applink/  */
 /* for more information */
 
 


### PR DESCRIPTION
Hello,

This PR contains the necessary changes to fix the broken or moved links listed below.

## Link Updates

### 1. OpenDNSSec SoftHSM
- **Old:** `https://www.opendnssec.org/softhsm/`
- **New:** `https://www.opendnssec.org/en/latest/softhsm/`
- **Reason:** Link content has been moved, no visual display at old address.

### 2. Oracle PKCS#11 Reference Guide
- **Old:** `https://docs.oracle.com/en/java/javase/11/security/pkcs11-reference-guide1.html`
- **New:** `https://docs.oracle.com/en/java/javase/11/security/pkcs11-reference-guide.html`
- **Reason:** Link content has been moved. The `1` at the end of `guide1` has been removed.

### 3. Dmalloc Library
- **Old:** `https://dmalloc.org/`
- **New:** `https://dmalloc.com/`
- **Reason:** The `org` domain has changed to `com`.

### 4. OpenSSL Applink
- **Old:** `https://www.openssl.org/support/faq.html#PROG2`
- **New:** `https://docs.openssl.org/1.1.1/man3/OPENSSL_Applink/`
- **Reason:** OpenSSL page changed long time ago. Consider removing link and keeping only the description.

### 5. Microsoft Console Documentation
- **Old:** `http://support.microsoft.com/kb/99261`
- **New:** `https://learn.microsoft.com/en-us/windows/console/clearing-the-screen`
- **Reason:** Link works but Knowledge Base format is old and content moved to learn.microsoft.com.

---

## Uncertain Links

The following links are related to deprecated/EOL systems (CentOS 7, RHEL 7). These may require architectural decisions rather than simple link updates, I am not sure what should be done for;

| File | URL | Issue |
|------|-----|-------|
| `github-build-ubuntu-latest.yml` | `softwarecollections.org/en/scls/rhscl/rh-git29/` | Site unavailable |
| `github-build-ubuntu-latest.yml` | `epel-release-latest-7.noarch.rpm` | CentOS 7 EOL |
| `github-build-ubuntu-latest.yml` | `ius-release-el7.rpm` | EL7 EOL |

---

Feel free to leave a comment for any modifications. I would be happy to help when available.

Best regards.