### PR TITLE
add support for token initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [UNPUBLISHED]
 ### Added
+- new command `p11init`, to initialize a token (`C_InitToken`) and/or its user/crypto officer PIN (`C_InitPIN`), or to reset (reinitialize) an existing token. The SO PIN and user PIN must be passed as arguments (`-O`/`-P`, the `PKCS11PASSWORD` environment variable is not honoured), the `:::exec:` convention is supported, slots are addressed by index, a batch mode is available (`-B`), and reinitializing an already initialized token requires the explicit `-R` flag (with an interactive confirmation unless in batch mode)
 - support public key extraction for libraries with non-compliant `CKA_EC_POINT` implementations (with no OCTET STRING encapsulation)
 - support for Docker builds
 - support for Windows 64-bit cross-compilation via MinGW-w64 (`buildx/Dockerfile.mingw64`)

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,6 +49,7 @@ completions_DATA = \
 	completion/bash/p11importcert \
 	completion/bash/p11importdata \
 	completion/bash/p11importpubk \
+	completion/bash/p11init \
 	completion/bash/p11kcv \
 	completion/bash/p11keycomp \
 	completion/bash/p11keygen \

--- a/README.md
+++ b/README.md
@@ -336,9 +336,9 @@ for f in completion/bash/p11*; do source "$f"; done
 To deregister the completions for the current shell:
 
 ```bash
-complete -r p11cat p11cp p11importcert p11importdata p11importpubk p11kcv \
-            p11keycomp p11keygen p11ls p11mkcert p11more p11mv p11od p11req \
-            p11rewrap p11rm p11setattr p11slotinfo p11unwrap p11wrap
+complete -r p11cat p11cp p11importcert p11importdata p11importpubk p11init \
+            p11kcv p11keycomp p11keygen p11ls p11mkcert p11more p11mv p11od \
+            p11req p11rewrap p11rm p11setattr p11slotinfo p11unwrap p11wrap
 ```
 
 To disable all programmable completion for the shell, use `shopt -u progcomp` (re-enable with `shopt -s progcomp`). To prevent completion from being installed at all, remove the files under `$(datadir)/bash-completion/completions/p11*` and `$(datadir)/zsh/site-functions/_p11tools`; the binaries are unaffected.

--- a/completion/bash/p11init
+++ b/completion/bash/p11init
@@ -1,0 +1,49 @@
+# p11init(1) completion                                      -*- shell-script -*-
+#
+# Bash autocompletion for `p11init`.
+# Provides completions for options, slot indexes and token labels.
+#
+# Depends on:
+#   - ./p11-common
+
+source "$(dirname "${BASH_SOURCE[0]}")/p11-common"
+
+_p11init_opts="-l -m -s -t -I -R -U -O -P -T -B -h -V"
+
+_p11init() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  if [[ "$prev" == "-l" ]]; then
+    __p11_complete_filepath "$cur"
+    return
+  fi
+
+  if [[ "$prev" == "-m" ]]; then
+    __p11_complete_dirpath "$cur"
+    return
+  fi
+
+  if [[ "$prev" == "-s" ]]; then
+    __p11_complete_slots "$cur"
+    return
+  fi
+
+  if [[ "$prev" == "-t" ]]; then
+    __p11_complete_token_labels "$cur"
+    return
+  fi
+
+  # -O (SO PIN), -P (user PIN) and -T (new token label) take free-form,
+  # often sensitive values: intentionally offer no completion.
+  if [[ "$prev" == "-O" || "$prev" == "-P" || "$prev" == "-T" ]]; then
+    return
+  fi
+
+  if [[ "$cur" == -* ]]; then
+    __p11_complete_options "$cur" "${_p11init_opts}"
+    return
+  fi
+}
+
+complete -F _p11init p11init

--- a/completion/zsh/_p11tools.in
+++ b/completion/zsh/_p11tools.in
@@ -1,4 +1,4 @@
-#compdef p11cat p11cp p11importcert p11importdata p11importpubk p11kcv p11keycomp p11keygen p11ls p11mkcert p11more p11mv p11od p11req p11rewrap p11rm p11setattr p11slotinfo p11unwrap p11wrap
+#compdef p11cat p11cp p11importcert p11importdata p11importpubk p11init p11kcv p11keycomp p11keygen p11ls p11mkcert p11more p11mv p11od p11req p11rewrap p11rm p11setattr p11slotinfo p11unwrap p11wrap
 
 # Zsh completion for p11* tools
 # This file uses bashcompinit to load and reuse the existing Bash completions
@@ -19,8 +19,8 @@ source "$completion_dir/p11-common"
 
 # List of p11tools commands to load completions for
 _p11tools_cmds=(
-    p11cat p11cp p11importcert p11importdata p11importpubk p11kcv
-    p11keycomp p11keygen p11ls p11mkcert p11more p11mv p11od
+    p11cat p11cp p11importcert p11importdata p11importpubk p11init
+    p11kcv p11keycomp p11keygen p11ls p11mkcert p11more p11mv p11od
     p11req p11rewrap p11rm p11setattr p11slotinfo p11unwrap p11wrap
 )
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -79,6 +79,7 @@ The following commands are supported:
 | `p11rewrap`     | unwraps a key, and wrap it again under one or several wrapping key(s)            |
 | `masqreq`       | tunes a CSR to adjust DN and other fields (without re-signing)                   |
 | `p11mkcert`     | generates a self-signed certificate, suitable for Java JCA                       |
+| `p11init`       | initializes a token and/or its user PIN, or resets an existing token             |
 
 ## common arguments
 
@@ -1020,6 +1021,124 @@ xL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4o
 xL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4o
 xL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4oxL4o
 -----END CERTIFICATE REQUEST-----
+```
+
+## p11init
+
+`p11init` initializes a PKCS\#11 token and/or its user (crypto officer) PIN, and can also reset (reinitialize) an
+already initialized token. It maps directly to the PKCS\#11 `C_InitToken` and `C_InitPIN` functions.
+
+Unlike the other commands, `p11init` does **not** honour the `PKCS11PASSWORD`, `PKCS11SLOT` or `PKCS11TOKENLABEL`
+environment variables. Because its operations are destructive, the target token must always be made explicit on the
+command line (`-s`/`-t`, or chosen from the interactive list) and the PINs must always be passed as arguments or typed at
+the prompt — there are no hidden defaults coming from the environment. The `:::exec:<command>` convention is supported (to
+fetch a PIN from a subprocess), but the `:::nologin` convention is not.
+
+When running interactively (the default), any value that is not supplied on the command line is prompted for, mirroring the
+behaviour of the other commands. When neither a slot index (`-s`) nor a token label (`-t`) is given, `p11init` prints the
+**full slot list** and prompts for a slot index — exactly like `p11slotinfo` and the other commands. When a slot or token
+*is* given, the selected slot is displayed. The SO PIN and user PIN are read with echo turned off, so a terminal is
+required. Any PIN that is being **defined** interactively (the SO PIN when initializing a token, and the new user PIN)
+is asked **twice** and the two entries must match, to guard against a typo; a mismatch aborts the command without
+performing any action. In batch mode (`-B`), nothing is prompted: the slot/token must be known up-front and every required value
+**must** be passed as a command-line argument; the command fails safely (without performing any action) if anything is
+missing or inconsistent.
+
+Operations are selected with explicit flags, which can be combined:
+
+- `-I`: initialize a token (`C_InitToken`, Security Officer credentials). Needs a token label (`-T`) and the SO PIN
+  (`-O`); both are mandatory in batch mode, and prompted for in interactive mode.
+- `-U`: initialize/change the user (crypto officer) PIN (`C_InitPIN`). Needs the SO PIN (`-O`, used to log in as SO) and the
+  new user PIN (`-P`).
+- `-I -U`: do both, in one go (the token is initialized first, then the user PIN is set on the freshly created token).
+
+The slot is **not** filtered by compatibility: the whole list is shown and the chosen slot is validated *after* selection.
+For `-I`, the chosen slot must hold an **uninitialized** token, unless `-R` is given to authorize the (destructive)
+reinitialization of an already initialized one. For a standalone `-U`, an explicit `(y/N)` confirmation is requested before the
+user PIN is (re)set. While initializing, `p11init` also prints a short description of the operation being performed.
+
+Options are:
+
+- `-l <path>`: path to the PKCS\#11 library (or `PKCS11LIB`).
+- `-m <NSS config dir>`: NSS configuration directory (or `PKCS11NSSDIR`).
+- `-s <slot index>`: the slot **index**. When omitted in interactive mode, the slot list is shown and a
+  slot index is prompted for. In batch mode it must be provided (for `-I`, and for `-U` unless `-t` is used).
+  (The `PKCS11SLOT` environment variable is **not** read by `p11init`.)
+- `-t <token label>`: a token label, allowed **only** together with `-U` alone, to address an already initialized token.
+  It cannot be used with `-I`. (The `PKCS11TOKENLABEL` environment variable is **not** read by `p11init`.)
+- `-I`: initialize a token (see above). The chosen slot must hold an **uninitialized** token, unless `-R` is given.
+- `-R`: explicitly authorize the reinitialization (reset) of an **already initialized** token. This is a destructive
+  operation that erases all of the token content; it must be combined with `-I`. The slot may be picked interactively.
+- `-U`: initialize/change the user PIN (see above). A standalone `-U` asks for an explicit `(y/N)` confirmation before proceeding.
+- `-O <SO PIN | :::exec:<command>>`: the Security Officer PIN (prompted if omitted in interactive mode, mandatory in batch mode).
+- `-P <user PIN | :::exec:<command>>`: the new user PIN (used by `-U`; prompted if omitted in interactive mode).
+- `-T <token label>`: the token label to set when initializing a token (`-I`); mandatory in batch mode, prompted for in interactive mode.
+- `-B`: batch mode: never prompt. All required values must be passed as arguments, and interactive confirmations are skipped.
+- `-h`: print usage information.
+- `-V`: print version information.
+
+### Resetting (erasing) an existing token
+
+In PKCS\#11, calling `C_InitToken` on an already initialized token erases all of its content: this is how a token is
+reset. To avoid accidental data loss, `p11init` refuses to reinitialize an already initialized token unless the `-R`
+option is explicitly provided. With `-R`, the slot can be picked from the regular slot list (or given with `-s`). When
+running interactively (i.e. without `-B`), it then prints a warning showing the token being reset and asks for an
+explicit `(y/N)` confirmation (answer `y` then ENTER to proceed). In batch mode (`-B`), `-R` is sufficient and no prompt is displayed.
+
+Note that, as required by the standard, the SO PIN passed with `-O` when resetting an already initialized token must
+match the token's current SO PIN.
+
+### Examples
+
+Initialize a blank token at slot index `0`, setting its label and SO PIN:
+
+```
+$ p11init -l /path/to/libpkcs11.so -I -s 0 -O 12345678 -T "my token"
+Token at slot index 0 initialized successfully.
+```
+
+Set the user (crypto officer) PIN of an already initialized token, addressed by label:
+
+```
+$ p11init -l /path/to/libpkcs11.so -U -t "my token" -O 12345678 -P 87654321
+User (crypto officer) PIN initialized successfully.
+```
+
+Initialize a token and set its user PIN in a single invocation:
+
+```
+$ p11init -l /path/to/libpkcs11.so -I -U -s 0 -O 12345678 -P 87654321 -T "my token"
+Token at slot index 0 initialized successfully.
+User (crypto officer) PIN initialized successfully.
+```
+
+Reset (erase and reinitialize) an already initialized token, in batch mode:
+
+```
+$ p11init -l /path/to/libpkcs11.so -I -R -B -s 0 -O 12345678 -T "my token"
+Token at slot index 0 initialized successfully.
+```
+
+Fetch the SO PIN from a subprocess:
+
+```
+$ p11init -l /path/to/libpkcs11.so -U -t "my token" -O :::exec:\"getsopin -label my-token\" -P 87654321
+```
+
+Initialize a token interactively (the slot list is shown, then the slot index, token label and SO PIN are prompted):
+
+```
+$ p11init -l /path/to/libpkcs11.so -I
+PKCS#11 module slot list:
+Slot index: 0
+----------------
+...
+Enter slot index: 0
+Enter new token label: my token
+Enter Security Officer (SO) PIN:
+Confirm Security Officer (SO) PIN:
+Initializing token at slot index 0 with label 'my token'...
+Token at slot index 0 initialized successfully.
 ```
 
 ## p11wrap and p11unwrap

--- a/include/pkcs11lib.h
+++ b/include/pkcs11lib.h
@@ -842,6 +842,7 @@ size_t pkcs11_attribctx_get_allowed_mechanisms_len(attribCtx *ctx);
 /* Callback Prompt Strings */
 #define SLOT_PROMPT_STRING			"Enter slot index: "
 #define PASS_PROMPT_STRING			"Enter passphrase for token: "
+#define SO_PASS_PROMPT_STRING			"Enter Security Officer (SO) PIN for token: "
 // #define TOKEN_PASS_PROMPT_STRING		"Enter passphrase for token '%s': "
 
 #define MAXBUFSIZE              1024

--- a/include/pkcs11lib.h
+++ b/include/pkcs11lib.h
@@ -361,6 +361,7 @@ enum contenttype { ct_unknown,	/* unidentified app */
 /* pkcs11_utils.c */
 
 char * pkcs11_prompt( char *, CK_BBOOL );
+char * pkcs11_prompt_new_secret( char * prompt, char * confirm_prompt );
 void pkcs11_prompt_free_buffer(char *arg);
 char * pkcs11_pipe_password( char * passwordexec );
 func_rc prompt_for_hex(char *message, char *prompt, char *target, int len);
@@ -408,6 +409,17 @@ func_rc pkcs11_finalize( pkcs11Context * );
 /* pkcs11_GetSession.c */
 func_rc pkcs11_open_session( pkcs11Context * p11Context, int slot, char *tokenlabel, char * password, int so, int interactive );
 func_rc pkcs11_close_session( pkcs11Context * p11Context );
+
+/* pkcs11_init.c */
+/* tokenlabelcmp (defined in pkcs11_session.c): compare a (trimmed) label against */
+/* a possibly space-padded, non null-terminated token label of given max length.  */
+/* Returns 0 when they match.                                                      */
+int tokenlabelcmp( const char *label, const char *reflabel, size_t reflabel_maxlen );
+
+func_rc pkcs11_get_slotindex( pkcs11Context * p11Context, int *slotindex, char *tokenlabel, int interactive );
+func_rc pkcs11_inittoken_guard( pkcs11Context * p11Context, int slotindex, int reset_authorized, int interactive );
+func_rc pkcs11_init_token( pkcs11Context * p11Context, int slotindex, char *sopin, char *label, int reset_authorized, int interactive );
+func_rc pkcs11_init_pin( pkcs11Context * p11Context, char *userpin, int interactive );
 
 // int setKeyLabel( pkcs11Context *, CK_OBJECT_HANDLE, char * );
 // int showKey( pkcs11Context *, CK_OBJECT_HANDLE );

--- a/include/pkcs11lib.h
+++ b/include/pkcs11lib.h
@@ -416,9 +416,9 @@ func_rc pkcs11_close_session( pkcs11Context * p11Context );
 /* Returns 0 when they match.                                                      */
 int tokenlabelcmp( const char *label, const char *reflabel, size_t reflabel_maxlen );
 
-func_rc pkcs11_get_slotindex( pkcs11Context * p11Context, int *slotindex, char *tokenlabel, int interactive );
-func_rc pkcs11_inittoken_guard( pkcs11Context * p11Context, int slotindex, int reset_authorized, int interactive );
-func_rc pkcs11_init_token( pkcs11Context * p11Context, int slotindex, char *sopin, char *label, int reset_authorized, int interactive );
+func_rc pkcs11_get_slotindex( pkcs11Context * p11Context, int *slotindex, char *tokenlabel, CK_SLOT_ID *phSlot, int interactive );
+func_rc pkcs11_inittoken_guard( pkcs11Context * p11Context, CK_SLOT_ID hSlot, int slotindex, int reset_authorized, int interactive );
+func_rc pkcs11_init_token( pkcs11Context * p11Context, CK_SLOT_ID hSlot, int slotindex, char *sopin, char *label, int reset_authorized, int interactive );
 func_rc pkcs11_init_pin( pkcs11Context * p11Context, char *userpin, int interactive );
 
 // int setKeyLabel( pkcs11Context *, CK_OBJECT_HANDLE, char * );

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -60,6 +60,7 @@ libp11_la_SOURCES += pkcs11_attr.c \
 	pkcs11_error.c \
 	pkcs11_context.c \
 	pkcs11_session.c \
+	pkcs11_init.c \
 	pkcs11_template.c \
 	pkcs11_kcv.c \
 	pkcs11_keycomp.c \

--- a/lib/pkcs11_init.c
+++ b/lib/pkcs11_init.c
@@ -145,11 +145,16 @@ static CK_BBOOL parse_slot_index_input(const char *input, long *out)
 **                 to a valid slot index.
 **  - tokenlabel:  when non-NULL, the slot is resolved by matching this token
 **                 label instead of using slotindex.
+**  - phSlot:      when non-NULL, receives the CK_SLOT_ID of the resolved slot,
+**                 captured during the same slot-list enumeration used to select
+**                 it. This lets the caller address the token directly, without a
+**                 second C_GetSlotList (and the slot-list change that could occur
+**                 in between).
 **  - interactive: when non-zero, an unspecified slot triggers the display of the
 **                 slot list and an interactive prompt; otherwise the function
 **                 fails safely.
 */
-func_rc pkcs11_get_slotindex(pkcs11Context *p11Context, int *slotindex, char *tokenlabel, int interactive)
+func_rc pkcs11_get_slotindex(pkcs11Context *p11Context, int *slotindex, char *tokenlabel, CK_SLOT_ID *phSlot, int interactive)
 {
     CK_RV rv;
     func_rc rc = rc_ok;
@@ -200,6 +205,7 @@ func_rc pkcs11_get_slotindex(pkcs11Context *p11Context, int *slotindex, char *to
 	}
 
 	*slotindex = found;
+	if (phSlot) { *phSlot = pSlotList[found]; }
 	/* echo the selected slot */
 	print_slot_entry(p11Context, pSlotList[found], (CK_ULONG)found);
 	goto err;		/* rc is still rc_ok */
@@ -207,6 +213,7 @@ func_rc pkcs11_get_slotindex(pkcs11Context *p11Context, int *slotindex, char *to
 
     /* if a valid slot index has already been provided, echo it and we are done */
     if (*slotindex >= 0 && (CK_ULONG)*slotindex < ulSlotCount) {
+	if (phSlot) { *phSlot = pSlotList[*slotindex]; }
 	print_slot_entry(p11Context, pSlotList[*slotindex], (CK_ULONG)*slotindex);
 	goto err;		/* rc is still rc_ok */
     }
@@ -271,59 +278,7 @@ func_rc pkcs11_get_slotindex(pkcs11Context *p11Context, int *slotindex, char *to
     }
 
     *slotindex = (int)s;
-
-err:
-    if (pSlotList) { free(pSlotList); }
-    return rc;
-}
-
-
-/* slot_index_to_token_info: resolve a slot index to its CK_SLOT_ID and fetch the
-** corresponding CK_TOKEN_INFO. The index is validated against the current slot list.
-*/
-static func_rc slot_index_to_token_info(pkcs11Context *p11Context,
-					int slotindex,
-					CK_SLOT_ID *phSlot,
-					CK_TOKEN_INFO *pTokenInfo)
-{
-    CK_RV rv;
-    func_rc rc = rc_ok;
-    CK_SLOT_ID_PTR pSlotList = NULL;
-    CK_ULONG ulSlotCount = 0;
-
-    if ((rv = p11Context->FunctionList.C_GetSlotList(CK_FALSE, NULL_PTR, &ulSlotCount)) != CKR_OK) {
-	pkcs11_error(rv, "C_GetSlotList");
-	rc = rc_error_pkcs11_api;
-	goto err;
-    }
-
-    if ((pSlotList = (CK_SLOT_ID_PTR) malloc(ulSlotCount * sizeof(CK_SLOT_ID))) == NULL) {
-	fprintf(stderr, "Error: No memory available\n");
-	rc = rc_error_memory;
-	goto err;
-    }
-
-    if ((rv = p11Context->FunctionList.C_GetSlotList(CK_FALSE, pSlotList, &ulSlotCount)) != CKR_OK) {
-	pkcs11_error(rv, "C_GetSlotList");
-	rc = rc_error_pkcs11_api;
-	goto err;
-    }
-
-    /* the token is always addressed by slot index for token initialization */
-    if (slotindex < 0 || (CK_ULONG)slotindex >= ulSlotCount) {
-	fprintf(stderr, "*** Error: slot index value %d not within range [0,%lu]\n",
-		slotindex, ulSlotCount > 0 ? ulSlotCount - 1 : 0);
-	rc = rc_error_invalid_slot_or_token;
-	goto err;
-    }
-
-    *phSlot = pSlotList[slotindex];
-
-    if ((rv = p11Context->FunctionList.C_GetTokenInfo(*phSlot, pTokenInfo)) != CKR_OK) {
-	pkcs11_error(rv, "C_GetTokenInfo");
-	rc = (rv == CKR_TOKEN_NOT_PRESENT) ? rc_error_invalid_slot_or_token : rc_error_pkcs11_api;
-	goto err;
-    }
+    if (phSlot) { *phSlot = pSlotList[s]; }
 
 err:
     if (pSlotList) { free(pSlotList); }
@@ -340,19 +295,23 @@ err:
 ** operator for a label/PIN -- when the chosen slot cannot or should not be
 ** (re)initialized.
 **
+** hSlot is the CK_SLOT_ID resolved by the caller (pkcs11_get_slotindex); the
+** token info is fetched directly from it. slotindex is used only for messages.
+**
 ** returns rc_ok when initialization may proceed.
 */
 func_rc pkcs11_inittoken_guard(pkcs11Context *p11Context,
+			       CK_SLOT_ID hSlot,
 			       int slotindex,
 			       int reset_authorized,
 			       int interactive)
 {
-    func_rc rc;
-    CK_SLOT_ID hSlot;
+    CK_RV rv;
     CK_TOKEN_INFO tokenInfo;
 
-    if ((rc = slot_index_to_token_info(p11Context, slotindex, &hSlot, &tokenInfo)) != rc_ok) {
-	return rc;
+    if ((rv = p11Context->FunctionList.C_GetTokenInfo(hSlot, &tokenInfo)) != CKR_OK) {
+	pkcs11_error(rv, "C_GetTokenInfo");
+	return (rv == CKR_TOKEN_NOT_PRESENT) ? rc_error_invalid_slot_or_token : rc_error_pkcs11_api;
     }
 
     /* guard against accidental destruction of an already initialized token */
@@ -398,8 +357,13 @@ func_rc pkcs11_inittoken_guard(pkcs11Context *p11Context,
 ** arguments:
 **  - p11Context: an initialized context (C_Initialize already called), with NO
 **                open session on the target token (a requirement of C_InitToken).
-**  - slotindex: index of the slot in the slot list (NOT a slot number). It must
-**               be a valid index (see pkcs11_get_slotindex).
+**  - hSlot: the CK_SLOT_ID of the target slot, as resolved by the caller through
+**           pkcs11_get_slotindex. The token is addressed directly by this slot ID;
+**           no second slot-list enumeration is performed. C_InitToken is the last
+**           use of hSlot, so a provider that reassigns slot IDs after token
+**           initialization (e.g. SoftHSM) does not affect this call.
+**  - slotindex: index of the slot in the slot list (NOT a slot number), used only
+**               for human-readable progress and error messages.
 **  - sopin: the Security Officer PIN (must already be resolved, never NULL).
 **  - label: the token label to set (will be space-padded to the field length).
 **  - reset_authorized: when non-zero, allows reinitializing an already
@@ -413,6 +377,7 @@ func_rc pkcs11_inittoken_guard(pkcs11Context *p11Context,
 ** pkcs11_inittoken_guard so that it happens before any label/PIN is collected.
 */
 func_rc pkcs11_init_token(pkcs11Context *p11Context,
+			  CK_SLOT_ID hSlot,
 			  int slotindex,
 			  char *sopin,
 			  char *label,
@@ -421,7 +386,6 @@ func_rc pkcs11_init_token(pkcs11Context *p11Context,
 {
     CK_RV rv;
     func_rc rc = rc_ok;
-    CK_SLOT_ID hSlot;
     CK_TOKEN_INFO tokenInfo;
     CK_UTF8CHAR paddedLabel[CK_TOKEN_INFO_LABEL_LEN];
     size_t labelLen;
@@ -448,8 +412,10 @@ func_rc pkcs11_init_token(pkcs11Context *p11Context,
 	goto err;
     }
 
-    /* resolve the slot index to its slot ID and current token info */
-    if ((rc = slot_index_to_token_info(p11Context, slotindex, &hSlot, &tokenInfo)) != rc_ok) {
+    /* fetch the current token info for the slot resolved by the caller */
+    if ((rv = p11Context->FunctionList.C_GetTokenInfo(hSlot, &tokenInfo)) != CKR_OK) {
+	pkcs11_error(rv, "C_GetTokenInfo");
+	rc = (rv == CKR_TOKEN_NOT_PRESENT) ? rc_error_invalid_slot_or_token : rc_error_pkcs11_api;
 	goto err;
     }
 

--- a/lib/pkcs11_init.c
+++ b/lib/pkcs11_init.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <errno.h>
 #include "pkcs11lib.h"
 
 /* the PKCS#11 token label field is a fixed-size, space-padded, */
@@ -90,6 +91,44 @@ static void print_slot_entry(pkcs11Context *p11Context, CK_SLOT_ID slotID, CK_UL
 }
 
 
+/* parse_slot_index_input: parse and validate a user-provided slot index string.
+**
+** accepted format: optional leading/trailing spaces and a signed decimal integer.
+** rejected format: empty string, non-digit junk, and out-of-range values.
+*/
+static CK_BBOOL parse_slot_index_input(const char *input, long *out)
+{
+	char *endptr = NULL;
+
+	if (input == NULL || out == NULL) {
+	return CK_FALSE;
+	}
+
+	errno = 0;
+	*out = strtol(input, &endptr, 10);
+
+	/* no digit parsed */
+	if (endptr == input) {
+	return CK_FALSE;
+	}
+
+	/* only ERANGE is portable to detect overflow/underflow with strtol */
+	if (errno == ERANGE) {
+	return CK_FALSE;
+	}
+
+	/* allow trailing spaces only */
+	while (*endptr != '\0') {
+	if (!isspace((unsigned char)*endptr)) {
+	    return CK_FALSE;
+	}
+	endptr++;
+	}
+
+	return CK_TRUE;
+}
+
+
 /* pkcs11_get_slotindex: resolve a slot index, in the same fashion as the other
 **                       commands (pkcs11_open_session): when a slot index or a
 **                       token label is given, it is resolved (and the selected
@@ -100,12 +139,12 @@ static void print_slot_entry(pkcs11Context *p11Context, CK_SLOT_ID slotID, CK_UL
 **                       is left to the caller.
 **
 ** arguments:
-**  - p11Context: an initialized context (C_Initialize already called).
-**  - slotindex: in/out pointer to the slot index. On input, a negative or
-**               out-of-range value means "not specified". On success, it is set
-**               to a valid slot index.
-**  - tokenlabel: when non-NULL, the slot is resolved by matching this token
-**                label instead of using slotindex.
+**  - p11Context:  an initialized context (C_Initialize already called).
+**  - slotindex:   in/out pointer to the slot index. On input, a negative or
+**                 out-of-range value means "not specified". On success, it is set
+**                 to a valid slot index.
+**  - tokenlabel:  when non-NULL, the slot is resolved by matching this token
+**                 label instead of using slotindex.
 **  - interactive: when non-zero, an unspecified slot triggers the display of the
 **                 slot list and an interactive prompt; otherwise the function
 **                 fails safely.
@@ -121,7 +160,6 @@ func_rc pkcs11_get_slotindex(pkcs11Context *p11Context, int *slotindex, char *to
     CK_ULONG i;
     long s;
     char *tmpSlot = NULL;
-    char *pEnd = NULL;
 
     if ((rv = p11Context->FunctionList.C_GetSlotList(CK_FALSE, NULL_PTR, &ulSlotCount)) != CKR_OK) {
 	pkcs11_error(rv, "C_GetSlotList");
@@ -216,7 +254,13 @@ func_rc pkcs11_get_slotindex(pkcs11Context *p11Context, int *slotindex, char *to
 	    goto err;
 	}
 
-	s = strtol(tmpSlot, &pEnd, 0);
+	if (parse_slot_index_input(tmpSlot, &s) != CK_TRUE) {
+	    fprintf(stderr,
+		    "*** Error: invalid slot index '%s' (expected a decimal integer)\n",
+		    tmpSlot);
+	    pkcs11_prompt_free_buffer(tmpSlot);
+	    continue;
+	}
 	pkcs11_prompt_free_buffer(tmpSlot);
 
 	if (s >= 0 && (CK_ULONG)s < ulSlotCount) {

--- a/lib/pkcs11_init.c
+++ b/lib/pkcs11_init.c
@@ -1,0 +1,501 @@
+/* -*- mode: c; c-file-style:"stroustrup"; -*- */
+
+/*
+ * Copyright (c) 2018 Mastercard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include "pkcs11lib.h"
+
+/* the PKCS#11 token label field is a fixed-size, space-padded, */
+/* NON null-terminated field of CK_TOKEN_INFO_LABEL_LEN octets.  */
+#define CK_TOKEN_INFO_LABEL_LEN 32
+
+#define NEW_USER_PIN_PROMPT_STRING "Enter new user (crypto officer) PIN: "
+#define NEW_USER_PIN_CONFIRM_PROMPT_STRING "Confirm new user (crypto officer) PIN: "
+
+/* ask_confirmation: interactive yes/no confirmation prompt.
+**
+** aligned with the other commands (p11rm, p11mv, ...): the prompt ends with
+** '(y/N)', a whole line is read, and the answer is accepted when its first
+** character is 'y' or 'Y'. Anything else (including an empty line) is a refusal.
+**
+** returns CK_TRUE when the user confirms, CK_FALSE otherwise.
+*/
+static CK_BBOOL ask_confirmation(const char *prompt)
+{
+    CK_BBOOL confirmed = CK_FALSE;
+    char *answer = pkcs11_prompt((char *)prompt, CK_TRUE);
+
+    if (answer != NULL) {
+	if (tolower((unsigned char)answer[0]) == 'y') {
+	    confirmed = CK_TRUE;
+	}
+	pkcs11_prompt_free_buffer(answer);
+    }
+
+    return confirmed;
+}
+
+
+/* print_slot_entry: print a slot/token description block, in the same layout as
+** the interactive slot list used across the other commands.
+*/
+static void print_slot_entry(pkcs11Context *p11Context, CK_SLOT_ID slotID, CK_ULONG index)
+{
+    CK_RV rv;
+    CK_SLOT_INFO slotInfo;
+    CK_TOKEN_INFO tokenInfo;
+
+    if ((rv = p11Context->FunctionList.C_GetSlotInfo(slotID, &slotInfo)) != CKR_OK) {
+	pkcs11_error(rv, "C_GetSlotInfo");
+	return;
+    }
+
+    fprintf(stderr,
+	    "Slot index: %lu\n"
+	    "----------------\n"
+	    "Description : %.*s\n",
+	    index,
+	    (int)sizeof(slotInfo.slotDescription), slotInfo.slotDescription);
+
+    if ((rv = p11Context->FunctionList.C_GetTokenInfo(slotID, &tokenInfo)) != CKR_OK) {
+	if (rv != CKR_TOKEN_NOT_PRESENT) { /* no token: silently pass, this is not an error */
+	    pkcs11_error(rv, "C_GetTokenInfo");
+	}
+	fprintf(stderr, "(no token present)\n\n");
+    } else {
+	fprintf(stderr,
+		"Token Label : %.*s\n"
+		"Manufacturer: %.*s\n\n",
+		(int)sizeof(tokenInfo.label), tokenInfo.label,
+		(int)sizeof(tokenInfo.manufacturerID), tokenInfo.manufacturerID);
+    }
+}
+
+
+/* pkcs11_get_slotindex: resolve a slot index, in the same fashion as the other
+**                       commands (pkcs11_open_session): when a slot index or a
+**                       token label is given, it is resolved (and the selected
+**                       slot is displayed); otherwise, when interactive, the full
+**                       slot list is shown and a slot index is prompted for. No
+**                       compatibility filtering is performed here: checking that
+**                       the selected slot is suitable for the requested operation
+**                       is left to the caller.
+**
+** arguments:
+**  - p11Context: an initialized context (C_Initialize already called).
+**  - slotindex: in/out pointer to the slot index. On input, a negative or
+**               out-of-range value means "not specified". On success, it is set
+**               to a valid slot index.
+**  - tokenlabel: when non-NULL, the slot is resolved by matching this token
+**                label instead of using slotindex.
+**  - interactive: when non-zero, an unspecified slot triggers the display of the
+**                 slot list and an interactive prompt; otherwise the function
+**                 fails safely.
+*/
+func_rc pkcs11_get_slotindex(pkcs11Context *p11Context, int *slotindex, char *tokenlabel, int interactive)
+{
+    CK_RV rv;
+    func_rc rc = rc_ok;
+    CK_SLOT_ID_PTR pSlotList = NULL;
+    CK_ULONG ulSlotCount = 0;
+    CK_SLOT_INFO slotInfo;
+    CK_TOKEN_INFO tokenInfo;
+    CK_ULONG i;
+    long s;
+    char *tmpSlot = NULL;
+    char *pEnd = NULL;
+
+    if ((rv = p11Context->FunctionList.C_GetSlotList(CK_FALSE, NULL_PTR, &ulSlotCount)) != CKR_OK) {
+	pkcs11_error(rv, "C_GetSlotList");
+	rc = rc_error_pkcs11_api;
+	goto err;
+    }
+
+    if ((pSlotList = (CK_SLOT_ID_PTR) malloc(ulSlotCount * sizeof(CK_SLOT_ID))) == NULL) {
+	fprintf(stderr, "Error: No memory available\n");
+	rc = rc_error_memory;
+	goto err;
+    }
+
+    if ((rv = p11Context->FunctionList.C_GetSlotList(CK_FALSE, pSlotList, &ulSlotCount)) != CKR_OK) {
+	pkcs11_error(rv, "C_GetSlotList");
+	rc = rc_error_pkcs11_api;
+	goto err;
+    }
+
+    /* if a token label is given, resolve it to a slot index */
+    if (tokenlabel != NULL) {
+	int found = -1;
+
+	for (i = 0; i < ulSlotCount; i++) {
+	    if (p11Context->FunctionList.C_GetTokenInfo(pSlotList[i], &tokenInfo) != CKR_OK) {
+		continue;	/* no token here, skip */
+	    }
+	    if (tokenlabelcmp(tokenlabel, (const char *)tokenInfo.label, sizeof tokenInfo.label) == 0) {
+		found = (int)i;
+		break;
+	    }
+	}
+
+	if (found < 0) {
+	    fprintf(stderr, "*** Error: token with label '%s' not found\n", tokenlabel);
+	    rc = rc_error_invalid_slot_or_token;
+	    goto err;
+	}
+
+	*slotindex = found;
+	/* echo the selected slot */
+	print_slot_entry(p11Context, pSlotList[found], (CK_ULONG)found);
+	goto err;		/* rc is still rc_ok */
+    }
+
+    /* if a valid slot index has already been provided, echo it and we are done */
+    if (*slotindex >= 0 && (CK_ULONG)*slotindex < ulSlotCount) {
+	print_slot_entry(p11Context, pSlotList[*slotindex], (CK_ULONG)*slotindex);
+	goto err;		/* rc is still rc_ok */
+    }
+
+    /* otherwise, in batch mode we fail safely */
+    if (!interactive) {
+	fprintf(stderr, "*** Error: slot index value %d not within range [0,%lu]\n",
+		*slotindex, ulSlotCount > 0 ? ulSlotCount - 1 : 0);
+	rc = rc_error_invalid_slot_or_token;
+	goto err;
+    }
+
+    /* interactive: list all slots and ask to pick one */
+    fprintf(stderr, "PKCS#11 module slot list:\n");
+
+    for (i = 0; i < ulSlotCount; i++) {
+	if ((rv = p11Context->FunctionList.C_GetSlotInfo(pSlotList[i], &slotInfo)) != CKR_OK) {
+	    pkcs11_error(rv, "C_GetSlotInfo");
+	} else {
+	    fprintf(stderr,
+		    "Slot index: %lu\n"
+		    "----------------\n"
+		    "Description : %.*s\n",
+		    i,
+		    (int)sizeof(slotInfo.slotDescription), slotInfo.slotDescription);
+
+	    if ((rv = p11Context->FunctionList.C_GetTokenInfo(pSlotList[i], &tokenInfo)) != CKR_OK) {
+		if (rv != CKR_TOKEN_NOT_PRESENT) { /* no token: silently pass, this is not an error */
+		    pkcs11_error(rv, "C_GetTokenInfo");
+		}
+	    } else {
+		fprintf(stderr,
+			"Token Label : %.*s\n"
+			"Manufacturer: %.*s\n\n",
+			(int)sizeof(tokenInfo.label), tokenInfo.label,
+			(int)sizeof(tokenInfo.manufacturerID), tokenInfo.manufacturerID);
+	    }
+	}
+    }
+
+    while (1) {
+	tmpSlot = pkcs11_prompt(SLOT_PROMPT_STRING, CK_TRUE);
+	if (tmpSlot == NULL) {
+	    rc = rc_error_prompt;
+	    goto err;
+	}
+
+	s = strtol(tmpSlot, &pEnd, 0);
+	pkcs11_prompt_free_buffer(tmpSlot);
+
+	if (s >= 0 && (CK_ULONG)s < ulSlotCount) {
+	    break;
+	}
+	fprintf(stderr, "*** Error: slot index value %ld not within range [0,%lu]\n",
+		s, ulSlotCount > 0 ? ulSlotCount - 1 : 0);
+    }
+
+    *slotindex = (int)s;
+
+err:
+    if (pSlotList) { free(pSlotList); }
+    return rc;
+}
+
+
+/* slot_index_to_token_info: resolve a slot index to its CK_SLOT_ID and fetch the
+** corresponding CK_TOKEN_INFO. The index is validated against the current slot list.
+*/
+static func_rc slot_index_to_token_info(pkcs11Context *p11Context,
+					int slotindex,
+					CK_SLOT_ID *phSlot,
+					CK_TOKEN_INFO *pTokenInfo)
+{
+    CK_RV rv;
+    func_rc rc = rc_ok;
+    CK_SLOT_ID_PTR pSlotList = NULL;
+    CK_ULONG ulSlotCount = 0;
+
+    if ((rv = p11Context->FunctionList.C_GetSlotList(CK_FALSE, NULL_PTR, &ulSlotCount)) != CKR_OK) {
+	pkcs11_error(rv, "C_GetSlotList");
+	rc = rc_error_pkcs11_api;
+	goto err;
+    }
+
+    if ((pSlotList = (CK_SLOT_ID_PTR) malloc(ulSlotCount * sizeof(CK_SLOT_ID))) == NULL) {
+	fprintf(stderr, "Error: No memory available\n");
+	rc = rc_error_memory;
+	goto err;
+    }
+
+    if ((rv = p11Context->FunctionList.C_GetSlotList(CK_FALSE, pSlotList, &ulSlotCount)) != CKR_OK) {
+	pkcs11_error(rv, "C_GetSlotList");
+	rc = rc_error_pkcs11_api;
+	goto err;
+    }
+
+    /* the token is always addressed by slot index for token initialization */
+    if (slotindex < 0 || (CK_ULONG)slotindex >= ulSlotCount) {
+	fprintf(stderr, "*** Error: slot index value %d not within range [0,%lu]\n",
+		slotindex, ulSlotCount > 0 ? ulSlotCount - 1 : 0);
+	rc = rc_error_invalid_slot_or_token;
+	goto err;
+    }
+
+    *phSlot = pSlotList[slotindex];
+
+    if ((rv = p11Context->FunctionList.C_GetTokenInfo(*phSlot, pTokenInfo)) != CKR_OK) {
+	pkcs11_error(rv, "C_GetTokenInfo");
+	rc = (rv == CKR_TOKEN_NOT_PRESENT) ? rc_error_invalid_slot_or_token : rc_error_pkcs11_api;
+	goto err;
+    }
+
+err:
+    if (pSlotList) { free(pSlotList); }
+    return rc;
+}
+
+
+/* pkcs11_inittoken_guard: check whether a token may be initialized at the given
+** slot index, BEFORE any token label or SO PIN is collected.
+**
+** It rejects an already initialized token unless reset_authorized is set, and
+** (when interactive) prints a destruction warning and asks for an explicit
+** confirmation. This lets the caller bail out early -- and avoid prompting the
+** operator for a label/PIN -- when the chosen slot cannot or should not be
+** (re)initialized.
+**
+** returns rc_ok when initialization may proceed.
+*/
+func_rc pkcs11_inittoken_guard(pkcs11Context *p11Context,
+			       int slotindex,
+			       int reset_authorized,
+			       int interactive)
+{
+    func_rc rc;
+    CK_SLOT_ID hSlot;
+    CK_TOKEN_INFO tokenInfo;
+
+    if ((rc = slot_index_to_token_info(p11Context, slotindex, &hSlot, &tokenInfo)) != rc_ok) {
+	return rc;
+    }
+
+    /* guard against accidental destruction of an already initialized token */
+    if (tokenInfo.flags & CKF_TOKEN_INITIALIZED) {
+	if (!reset_authorized) {
+	    fprintf(stderr,
+		    "*** Error: token at slot index %d is already initialized.\n"
+		    "           Reinitializing it would ERASE ALL of its content.\n"
+		    "           To proceed, you must explicitly request a reset (-R option).\n",
+		    slotindex);
+	    return rc_error_usage;
+	}
+
+	if (interactive) {
+	    fprintf(stderr,
+		    "\n"
+		    "*** WARNING: about to REINITIALIZE an already initialized token. ***\n"
+		    "All objects and credentials stored on this token will be PERMANENTLY ERASED.\n"
+		    "\n"
+		    "  slot index  : %d\n"
+		    "  token label : %.*s\n"
+		    "  manufacturer: %.*s\n"
+		    "  serial      : %.*s\n"
+		    "\n",
+		    slotindex,
+		    (int)sizeof(tokenInfo.label), tokenInfo.label,
+		    (int)sizeof(tokenInfo.manufacturerID), tokenInfo.manufacturerID,
+		    (int)sizeof(tokenInfo.serialNumber), tokenInfo.serialNumber);
+
+	    if (ask_confirmation("reinitialize (ERASE) this token ? (y/N)") != CK_TRUE) {
+		fprintf(stderr, "Aborted: token has NOT been reinitialized.\n");
+		return rc_error_other_error;
+	    }
+	}
+    }
+
+    return rc_ok;
+}
+
+
+/* pkcs11_init_token: initialize (or reinitialize) a token through C_InitToken.
+**
+** arguments:
+**  - p11Context: an initialized context (C_Initialize already called), with NO
+**                open session on the target token (a requirement of C_InitToken).
+**  - slotindex: index of the slot in the slot list (NOT a slot number). It must
+**               be a valid index (see pkcs11_get_slotindex).
+**  - sopin: the Security Officer PIN (must already be resolved, never NULL).
+**  - label: the token label to set (will be space-padded to the field length).
+**  - reset_authorized: when non-zero, allows reinitializing an already
+**                      initialized token (destructive operation).
+**  - interactive: unused here; the destructive confirmation is handled upfront by
+**                 pkcs11_inittoken_guard, which the caller must invoke first.
+**
+** Initializing an already initialized token erases all of its content. As a safety
+** net this function still refuses to proceed on an initialized token unless
+** reset_authorized is set; the interactive warning/confirmation lives in
+** pkcs11_inittoken_guard so that it happens before any label/PIN is collected.
+*/
+func_rc pkcs11_init_token(pkcs11Context *p11Context,
+			  int slotindex,
+			  char *sopin,
+			  char *label,
+			  int reset_authorized,
+			  int interactive)
+{
+    CK_RV rv;
+    func_rc rc = rc_ok;
+    CK_SLOT_ID hSlot;
+    CK_TOKEN_INFO tokenInfo;
+    CK_UTF8CHAR paddedLabel[CK_TOKEN_INFO_LABEL_LEN];
+    size_t labelLen;
+
+    (void)interactive; /* destruction confirmation is handled by pkcs11_inittoken_guard */
+
+    if (sopin == NULL) {
+	fprintf(stderr, "*** Error: a SO PIN is required to initialize a token\n");
+	rc = rc_error_usage;
+	goto err;
+    }
+
+    if (label == NULL) {
+	fprintf(stderr, "*** Error: a token label is required to initialize a token\n");
+	rc = rc_error_usage;
+	goto err;
+    }
+
+    labelLen = strlen(label);
+    if (labelLen > CK_TOKEN_INFO_LABEL_LEN) {
+	fprintf(stderr, "*** Error: token label '%s' is longer than %d characters\n",
+		label, CK_TOKEN_INFO_LABEL_LEN);
+	rc = rc_error_invalid_label;
+	goto err;
+    }
+
+    /* resolve the slot index to its slot ID and current token info */
+    if ((rc = slot_index_to_token_info(p11Context, slotindex, &hSlot, &tokenInfo)) != rc_ok) {
+	goto err;
+    }
+
+    /* safety net: never erase an already initialized token without authorization. */
+    /* The interactive destruction warning/confirmation is performed beforehand by */
+    /* pkcs11_inittoken_guard (so it happens before the label/PIN are collected).  */
+    if ((tokenInfo.flags & CKF_TOKEN_INITIALIZED) && !reset_authorized) {
+	fprintf(stderr,
+		"*** Error: token at slot index %d is already initialized.\n"
+		"           Reinitializing it would ERASE ALL of its content.\n"
+		"           To proceed, you must explicitly request a reset (-R option).\n",
+		slotindex);
+	rc = rc_error_usage;
+	goto err;
+    }
+
+    /* build the space-padded, non null-terminated label field */
+    memset(paddedLabel, ' ', sizeof paddedLabel);
+    memcpy(paddedLabel, label, labelLen);
+
+    /* be a bit verbose about the operation being performed (the selected slot */
+    /* details have already been displayed by the caller / slot selection).    */
+    fprintf(stderr, "%s token at slot index %d with label '%s'...\n",
+	    (tokenInfo.flags & CKF_TOKEN_INITIALIZED) ? "Reinitializing" : "Initializing",
+	    slotindex, label);
+
+
+    if ((rv = p11Context->FunctionList.C_InitToken(hSlot,
+						   (CK_UTF8CHAR_PTR) sopin,
+						   (CK_ULONG) strlen(sopin),
+						   paddedLabel)) != CKR_OK) {
+	pkcs11_error(rv, "C_InitToken");
+	rc = rc_error_pkcs11_api;
+	goto err;
+    }
+
+    fprintf(stderr, "Token at slot index %d initialized successfully.\n", slotindex);
+
+err:
+    return rc;
+}
+
+
+/* pkcs11_init_pin: set the normal user (crypto officer) PIN through C_InitPIN.
+**
+** arguments:
+**  - p11Context: a context with an already open R/W session, logged in as SO.
+**  - userpin: the new user PIN to set. When NULL and interactive is non-zero,
+**             the user is prompted for it.
+**  - interactive: when non-zero, prompt for the user PIN if it was not provided.
+**
+** C_InitPIN must be called on a session where the SO is logged in; the caller is
+** responsible for opening such a session (see pkcs11_open_session with so=1).
+*/
+func_rc pkcs11_init_pin(pkcs11Context *p11Context, char *userpin, int interactive)
+{
+    CK_RV rv;
+    func_rc rc = rc_ok;
+    char *prompted = NULL;
+    char *pin = userpin;
+
+    if (pin == NULL) {
+	if (!interactive) {
+	    fprintf(stderr, "*** Error: a user PIN is required to initialize the user PIN\n");
+	    rc = rc_error_usage;
+	    goto err;
+	}
+	/* the user PIN is being DEFINED, so confirm it (twice) to catch typos */
+	pin = prompted = pkcs11_prompt_new_secret(NEW_USER_PIN_PROMPT_STRING,
+						  NEW_USER_PIN_CONFIRM_PROMPT_STRING);
+	if (pin == NULL) {
+	    rc = rc_error_prompt;
+	    goto err;
+	}
+    }
+
+    /* be a bit verbose about the operation being performed */
+    fprintf(stderr, "Setting the user (crypto officer) PIN on slot index %d...\n", p11Context->slotindex);
+
+    if ((rv = p11Context->FunctionList.C_InitPIN(p11Context->Session,
+						 (CK_UTF8CHAR_PTR) pin,
+						 (CK_ULONG) strlen(pin))) != CKR_OK) {
+	pkcs11_error(rv, "C_InitPIN");
+	rc = rc_error_pkcs11_api;
+	goto err;
+    }
+
+    fprintf(stderr, "User (crypto officer) PIN initialized successfully.\n");
+
+err:
+    pkcs11_prompt_free_buffer(prompted);
+    return rc;
+}

--- a/lib/pkcs11_session.c
+++ b/lib/pkcs11_session.c
@@ -324,7 +324,7 @@ func_rc pkcs11_open_session( pkcs11Context * p11Context, int slot, char *tokenla
 
     if (password == NULL) {
 	/* prompt for password */
-	pass = cbpass = pkcs11_prompt( PASS_PROMPT_STRING, CK_FALSE );	
+	pass = cbpass = pkcs11_prompt( (so > 0) ? SO_PASS_PROMPT_STRING : PASS_PROMPT_STRING, CK_FALSE );
     } else if(strncmp(PASSWORD_EXEC, password, strlen(PASSWORD_EXEC)) == 0) {
 	/* execute a command and use output as password */
 	pass = cbpass = pkcs11_pipe_password(password);

--- a/lib/pkcs11_session.c
+++ b/lib/pkcs11_session.c
@@ -26,7 +26,7 @@
 
 
 /* prototypes and small/inline functions */
-static int tokenlabelcmp(const char *label, const char *reflabel, size_t reflabel_maxlen);
+/* tokenlabelcmp is exposed through pkcs11lib.h for reuse by other modules */
 static int _min(const int a, const int b);
 static int _max(const int a, const int b);
 
@@ -72,7 +72,7 @@ static inline int _max(const int a, const int b) {
 **          with a warning.
 */
 
-static int tokenlabelcmp(const char *label, const char *reflabel, size_t reflabel_maxlen)
+int tokenlabelcmp(const char *label, const char *reflabel, size_t reflabel_maxlen)
 {
 
     size_t label_len = strlen(label);

--- a/lib/pkcs11_utils.c
+++ b/lib/pkcs11_utils.c
@@ -29,7 +29,11 @@ static CK_ATTRIBUTE_PTR new_attribute_for_string(CK_ATTRIBUTE_TYPE argattrtype, 
 static CK_ATTRIBUTE_PTR new_attribute_for_null_term_string(CK_ATTRIBUTE_TYPE argattrtype, char *arg);
 static CK_ATTRIBUTE_PTR new_attribute_for_hex_string(CK_ATTRIBUTE_TYPE argattrtype, char *arg);
 
-char * pkcs11_prompt( char * prompt, CK_BBOOL echo )
+/* prompt_core: print a prompt and read a whole line from stdin, optionally with
+** echo turned off. No decorative leading/trailing newline is emitted; that is left
+** to the caller, so that prompts can be laid out compactly when several are chained.
+*/
+static char * prompt_core( char * prompt, CK_BBOOL echo )
 {
     char * buf = NULL;
     char * res = NULL;
@@ -41,7 +45,7 @@ char * pkcs11_prompt( char * prompt, CK_BBOOL echo )
 	exit( RC_ERROR_MEMORY );
     }
 
-    fprintf( stderr, "\n%s", prompt );
+    fprintf( stderr, "%s", prompt );
     fflush( stdout );
 
     if ( !echo ) {
@@ -80,13 +84,57 @@ char * pkcs11_prompt( char * prompt, CK_BBOOL echo )
 	pkcs11_ll_echo_on();
     }
 
-    printf("\n" );
+    return buf;
+}
+
+char * pkcs11_prompt( char * prompt, CK_BBOOL echo )
+{
+    char * buf;
+
+    fprintf( stderr, "\n" );
+    buf = prompt_core( prompt, echo );
+    printf( "\n" );
+
     return buf;
 }
 
 void pkcs11_prompt_free_buffer(char *arg)
 {
     if(arg) free(arg);
+}
+
+/* pkcs11_prompt_new_secret: prompt twice (with echo turned off) for a NEW secret
+** (e.g. a PIN being defined) and require both entries to be identical. This guards
+** against typos when setting a credential that cannot be verified otherwise.
+**
+** The two prompts are laid out compactly (one per line, no blank lines in between).
+**
+** Returns the confirmed secret on success (the caller must release it with
+** pkcs11_prompt_free_buffer), or NULL when the two entries do not match.
+*/
+char * pkcs11_prompt_new_secret( char * prompt, char * confirm_prompt )
+{
+    char * first;
+    char * second;
+    char * result = NULL;
+
+    fprintf( stderr, "\n" );
+    first = prompt_core( prompt, CK_FALSE );
+    fprintf( stderr, "\n" );
+    second = prompt_core( confirm_prompt, CK_FALSE );
+    fprintf( stderr, "\n" );
+
+    if ( first != NULL && second != NULL && strcmp( first, second ) == 0 ) {
+	result = first;
+	first = NULL; /* ownership transferred to the caller */
+    } else {
+	fprintf( stderr, "*** Error: the two entries do not match.\n" );
+    }
+
+    if ( first != NULL ) { pkcs11_prompt_free_buffer( first ); }
+    if ( second != NULL ) { pkcs11_prompt_free_buffer( second ); }
+
+    return result;
 }
 
 

--- a/lib/pkcs11_utils.c
+++ b/lib/pkcs11_utils.c
@@ -46,7 +46,7 @@ static char * prompt_core( char * prompt, CK_BBOOL echo )
     }
 
     fprintf( stderr, "%s", prompt );
-    fflush( stdout );
+    fflush( NULL );		/* flush all output streams */
 
     if ( !echo ) {
 	pkcs11_ll_echo_off();

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -20,3 +20,4 @@ p11slotinfo
 p11unwrap
 p11wrap
 p11rewrap
+p11init

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,7 +42,7 @@ libcommon_la_LDFLAGS = -static
 # p11 toolkit
 
 # the actual list of programs being compiled
-bin_PROGRAMS = p11mkcert p11rewrap p11wrap p11unwrap p11cp p11ls p11cat p11more p11od p11rm p11mv p11slotinfo p11req p11importcert p11importpubk p11importdata p11keycomp p11setattr masqreq p11keygen p11kcv
+bin_PROGRAMS = p11mkcert p11rewrap p11wrap p11unwrap p11cp p11ls p11cat p11more p11od p11rm p11mv p11slotinfo p11req p11importcert p11importpubk p11importdata p11keycomp p11setattr masqreq p11keygen p11kcv p11init
 
 
 SOURCES = $(bin_PROGRAMS:%=%.c)

--- a/src/p11init.c
+++ b/src/p11init.c
@@ -194,6 +194,7 @@ int main( int argc, char ** argv )
     int newlabel_allocated = 0;
     int session_opened = 0;
 
+    CK_SLOT_ID hSlot = 0;
     pkcs11Context * p11Context = NULL;
     func_rc retcode = rc_error_usage;
 
@@ -370,13 +371,13 @@ int main( int argc, char ** argv )
 	/* resolve the slot index, in the same fashion as the other commands:    */
 	/* when -s is given, echo the selected slot; otherwise (interactive) list */
 	/* all slots and prompt.                                                  */
-	if ( ( retcode = pkcs11_get_slotindex( p11Context, &slot, NULL, interactive ) ) != rc_ok ) {
+	if ( ( retcode = pkcs11_get_slotindex( p11Context, &slot, NULL, &hSlot, interactive ) ) != rc_ok ) {
 	    goto finalize;
 	}
 
 	/* check the chosen slot BEFORE collecting a token label / SO PIN: it must */
 	/* hold an uninitialized token, unless -R authorizes a (confirmed) reset.  */
-	if ( ( retcode = pkcs11_inittoken_guard( p11Context, slot, reset, interactive ) ) != rc_ok ) {
+	if ( ( retcode = pkcs11_inittoken_guard( p11Context, hSlot, slot, reset, interactive ) ) != rc_ok ) {
 	    goto finalize;
 	}
 
@@ -403,7 +404,7 @@ int main( int argc, char ** argv )
 	    }
 	}
 
-	retcode = pkcs11_init_token( p11Context, slot, sopin, newlabel, reset, interactive );
+	retcode = pkcs11_init_token( p11Context, hSlot, slot, sopin, newlabel, reset, interactive );
 	if ( retcode != rc_ok ) {
 	    goto finalize;
 	}
@@ -418,7 +419,7 @@ int main( int argc, char ** argv )
 
 	/* resolve and display the target slot (by label or index), or, when nothing */
 	/* is specified interactively, list all slots and prompt for one.            */
-	if ( ( retcode = pkcs11_get_slotindex( p11Context, &useslot, uselabel, interactive ) ) != rc_ok ) {
+	if ( ( retcode = pkcs11_get_slotindex( p11Context, &useslot, uselabel, NULL, interactive ) ) != rc_ok ) {
 	    goto finalize;
 	}
 

--- a/src/p11init.c
+++ b/src/p11init.c
@@ -119,7 +119,7 @@ void print_usage(char *progname)
 	     "  -h : print usage information\n"
 	     "  -V : print version information\n"
 	     "|\n"
-	     "+-> arguments marked with an asterix(*) are mandatory\n"
+	     "+-> arguments marked with an asterisk(*) are mandatory\n"
 	     "|   (except if environment variable sets the value)\n"
 	     "\n"
 	     " NOTES:\n"
@@ -145,9 +145,9 @@ void print_usage(char *progname)
 	     "\n"
 	     " ENVIRONMENT VARIABLES:\n"
 	     "    PKCS11LIB         : path to PKCS#11 library,\n"
-	     "                        overriden by option -l\n"
+	     "                        overridden by option -l\n"
 	     "    PKCS11NSSDIR      : NSS configuration directory directive,\n"
-	     "                        overriden by option -m\n"
+	     "                        overridden by option -m\n"
 	     "    (PKCS11SLOT, PKCS11TOKENLABEL and PKCS11PASSWORD are intentionally ignored)\n"
 	     "\n"
 	     , pkcs11_ll_basename(progname));
@@ -205,8 +205,21 @@ int main( int argc, char ** argv )
 	    break;
 
 	case 's':
-	    slot = atoi(optarg);
+	{
+	    /* using atoi() here could be dangerous, as an invalid parsing would return slot 0 */
+	    /* a more accurate way to capture the slot number is implemented with sscanf() */
+ 	    int tmp;
+ 	    char extra;
+ 	    if (sscanf(optarg, "%d%c", &tmp, &extra) != 1 || tmp < 0) {
+ 		fprintf(stderr,
+ 			"*** Error: invalid slot index '%s' (must be a non-negative integer).\n",
+ 			optarg);
+ 		errflag++;
+ 		break;
+ 	    }
+ 	    slot = tmp;
 	    break;
+	}
 
 	case 't':
 	    tokenlabel = optarg;

--- a/src/p11init.c
+++ b/src/p11init.c
@@ -88,7 +88,19 @@ static int resolve_pin(const char *what, char *arg, char **resolved, int *alloca
 	return 0;
     }
 
-    *resolved = arg;
+    /* literal PIN on the command line: copy it to a private buffer, then scrub */
+    /* the original argv bytes so the PIN no longer appears in ps(1) /          */
+    /* /proc/<pid>/cmdline for the remaining lifetime of the process.           */
+    {
+	char *copy = strdup(arg);
+	if (copy == NULL) {
+	    fprintf(stderr, "*** Error: out of memory while handling %s.\n", what);
+	    return 1;
+	}
+	memset(arg, 0, strlen(arg));
+	*resolved = copy;
+	*allocated = 1;
+    }
     return 0;
 }
 

--- a/src/p11init.c
+++ b/src/p11init.c
@@ -1,0 +1,438 @@
+/* -*- mode: c; c-file-style:"stroustrup"; -*- */
+
+/*
+ * Copyright (c) 2018 Mastercard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <unistd.h>
+#include "pkcs11lib.h"
+
+#ifdef _WIN32
+#include <openssl/applink.c>
+#endif
+
+#define COMMAND_SUMMARY \
+    "Initialize a PKCS#11 token and/or its user (crypto officer) PIN.\n"			\
+    "\n"										\
+    "Three operations are supported, and can be combined:\n"				\
+    "  -I : initialize a token (C_InitToken, Security Officer credentials)\n"		\
+    "  -U : initialize/change the user (crypto officer) PIN (C_InitPIN)\n"		\
+    "  -I -R : reinitialize (reset) an already initialized token (destructive)\n\n"
+
+#define SO_PIN_PROMPT_STRING   "Enter Security Officer (SO) PIN: "
+#define SO_PIN_CONFIRM_PROMPT_STRING "Confirm Security Officer (SO) PIN: "
+#define NEW_LABEL_PROMPT_STRING "Enter new token label: "
+#define CONFIRM_INITPIN_PROMPT_STRING \
+    "(re)set the user (crypto officer) PIN of this token ? (y/N)"
+
+
+/* prototypes */
+void print_version_info(char *progname);
+void print_usage(char *);
+int main( int argc, char **argv);
+
+
+/* resolve_pin: resolve a PIN argument provided on the command line.
+**
+** PIN arguments must be passed on the command line (the PKCS11PASSWORD environment
+** variable is intentionally NOT honoured by this command). The ':::exec:<command>'
+** convention is supported (the command output is used as the PIN). The ':::nologin'
+** convention is explicitly rejected.
+**
+** A NULL argument is not an error here: it means "not provided", and the caller is
+** expected to either prompt for it interactively (downstream) or fail in batch mode.
+**
+** On success, returns 0 and sets *resolved (possibly NULL when arg is NULL), and
+** *allocated to 1 when the returned buffer must be freed with
+** pkcs11_prompt_free_buffer(). On failure, returns non-zero.
+*/
+static int resolve_pin(const char *what, char *arg, char **resolved, int *allocated)
+{
+    *resolved = NULL;
+    *allocated = 0;
+
+    if (arg == NULL) {
+	return 0;		/* not provided: deferred to an interactive prompt downstream */
+    }
+
+    if (strcmp(arg, PASSWORD_NOLOGIN) == 0) {
+	fprintf(stderr, "*** Error: '%s' is not supported for %s.\n", PASSWORD_NOLOGIN, what);
+	return 1;
+    }
+
+    if (strncmp(PASSWORD_EXEC, arg, strlen(PASSWORD_EXEC)) == 0) {
+	char *piped = pkcs11_pipe_password(arg);
+	if (piped == NULL) {
+	    fprintf(stderr, "*** Error: could not retrieve %s from the specified command.\n", what);
+	    return 1;
+	}
+	*resolved = piped;
+	*allocated = 1;
+	return 0;
+    }
+
+    *resolved = arg;
+    return 0;
+}
+
+
+void print_usage(char *progname)
+{
+    fprintf( stderr,
+	     "USAGE: %s OPTIONS\n"
+	     "\n"
+	     COMMAND_SUMMARY
+	     "OPTIONS:\n"
+	     "* -l <pkcs#11 library path> : path to PKCS#11 library\n"
+	     "  -m <NSS config dir> ( e.g. '.' or 'sql:.' ) : NSS db directory\n"
+	     "  -s <slot index> : slot index. When omitted in interactive mode, the slot\n"
+	     "                    list is shown and a slot index is prompted for\n"
+	     "  -t <token label> : token label, allowed only together with -U alone\n"
+	     "                     (the token must already be initialized)\n"
+	     "  -I : initialize a token (in batch mode, requires -s, -O and -T)\n"
+	     "  -R : authorize reinitialization (reset) of an already initialized token\n"
+	     "       (destructive, must be combined with -I)\n"
+	     "  -U : initialize/change the user (crypto officer) PIN\n"
+	     "       (in batch mode, requires -O and -P, plus -s or -t)\n"
+	     "  -O <SO PIN | :::exec:<command>> : Security Officer PIN\n"
+	     "  -P <user PIN | :::exec:<command>> : new user (crypto officer) PIN (used by -U)\n"
+	     "  -T <token label> : token label to set when initializing a token (-I);\n"
+	     "                     mandatory in batch mode, prompted for otherwise\n"
+	     "  -B : batch mode, never prompt; all required values must be passed as arguments\n"
+	     "  -h : print usage information\n"
+	     "  -V : print version information\n"
+	     "|\n"
+	     "+-> arguments marked with an asterix(*) are mandatory\n"
+	     "|   (except if environment variable sets the value)\n"
+	     "\n"
+	     " NOTES:\n"
+	     "  - when run interactively (without -B) and no slot/token is given, the slot\n"
+	     "    list is shown and a slot index is prompted for; when -s/-t is given, the\n"
+	     "    selected slot is displayed. With -B, the slot/token must be known up-front.\n"
+	     "  - for -I, the chosen slot must hold an UNINITIALIZED token, unless -R is given\n"
+	     "    to authorize the (destructive) reinitialization of an already initialized one.\n"
+	     "  - for a standalone -U, an explicit confirmation (y/N) is requested before\n"
+	     "    the user PIN is (re)set.\n"
+	     "  - the SO PIN and user PIN are NEVER read from the PKCS11PASSWORD environment\n"
+	     "    variable; they must be passed as arguments or entered at the prompt.\n"
+	     "  - a PIN that is being DEFINED interactively (the SO PIN when initializing a\n"
+	     "    token, and the new user PIN) is asked twice and both entries must match.\n"
+	     "  - unlike the other commands, p11init does NOT read the slot (PKCS11SLOT) or\n"
+	     "    token label (PKCS11TOKENLABEL) from the environment: because its operations\n"
+	     "    are destructive, the target must always be given explicitly via -s/-t (or\n"
+	     "    selected from the interactive list).\n"
+	     "  - the ':::exec:<command>' convention is supported for -O and -P.\n"
+	     "  - the ':::nologin' convention is NOT supported.\n"
+	     "  - a token is addressed by its slot INDEX for -I; the token label (-t) may\n"
+	     "    only be used to address an already initialized token with -U.\n"
+	     "\n"
+	     " ENVIRONMENT VARIABLES:\n"
+	     "    PKCS11LIB         : path to PKCS#11 library,\n"
+	     "                        overriden by option -l\n"
+	     "    PKCS11NSSDIR      : NSS configuration directory directive,\n"
+	     "                        overriden by option -m\n"
+	     "    (PKCS11SLOT, PKCS11TOKENLABEL and PKCS11PASSWORD are intentionally ignored)\n"
+	     "\n"
+	     , pkcs11_ll_basename(progname));
+
+    exit( RC_ERROR_USAGE );
+}
+
+
+int main( int argc, char ** argv )
+{
+    extern char *optarg;
+    extern int optind;
+    int argnum = 0;
+    int errflag = 0;
+    char * library = NULL;
+    char * nsscfgdir = NULL;
+    int slot = -1;
+    char * tokenlabel = NULL;
+    char * sopinarg = NULL;
+    char * userpinarg = NULL;
+    char * newlabel = NULL;
+    int do_inittoken = 0;
+    int do_initpin = 0;
+    int reset = 0;
+    int batch = 0;
+    int interactive = 1;
+
+    char * sopin = NULL;
+    char * userpin = NULL;
+    int sopin_allocated = 0;
+    int userpin_allocated = 0;
+    int newlabel_allocated = 0;
+    int session_opened = 0;
+
+    pkcs11Context * p11Context = NULL;
+    func_rc retcode = rc_error_usage;
+
+    library = getenv("PKCS11LIB");
+    nsscfgdir = getenv("PKCS11NSSDIR");
+    /* Unlike the other commands, p11init intentionally does NOT read the slot   */
+    /* (PKCS11SLOT) or token label (PKCS11TOKENLABEL) from the environment:      */
+    /* its operations are destructive, so the target must be made explicit on    */
+    /* the command line. PKCS11PASSWORD is likewise not honoured.                */
+
+    while ( ( argnum = getopt( argc, argv, "l:m:s:t:IRUO:P:T:BhV" ) ) != -1 && errflag == 0 )
+    {
+	switch ( argnum )
+	{
+	case 'l':
+	    library = optarg;
+	    break;
+
+	case 'm':
+	    nsscfgdir = optarg;
+	    break;
+
+	case 's':
+	    slot = atoi(optarg);
+	    break;
+
+	case 't':
+	    tokenlabel = optarg;
+	    break;
+
+	case 'I':
+	    do_inittoken = 1;
+	    break;
+
+	case 'R':
+	    reset = 1;
+	    break;
+
+	case 'U':
+	    do_initpin = 1;
+	    break;
+
+	case 'O':
+	    sopinarg = optarg;
+	    break;
+
+	case 'P':
+	    userpinarg = optarg;
+	    break;
+
+	case 'T':
+	    newlabel = optarg;
+	    break;
+
+	case 'B':
+	    batch = 1;
+	    break;
+
+	case 'h':
+	    print_usage(argv[0]);
+	    break;
+
+	case 'V':
+	    print_version_info(argv[0]);
+	    break;
+
+	default:
+	    errflag++;
+	    break;
+	}
+    }
+
+    if ( errflag ) {
+	fprintf(stderr, "Try `%s -h' for more information.\n", argv[0]);
+	goto err;
+    }
+
+    /* --- safe-fail validation --- */
+
+    interactive = !batch;
+
+    if ( library == NULL ) {
+	fprintf(stderr, "*** Error: no PKCS#11 library specified (use -l or PKCS11LIB).\n");
+	goto err;
+    }
+
+    if ( !do_inittoken && !do_initpin ) {
+	fprintf(stderr, "*** Error: at least one operation must be requested (-I and/or -U).\n");
+	goto err;
+    }
+
+    if ( reset && !do_inittoken ) {
+	fprintf(stderr, "*** Error: -R (reset) requires -I (token initialization).\n");
+	goto err;
+    }
+
+    /* a token label (-t) may never be used to address a token for -I */
+    if ( do_inittoken && tokenlabel != NULL ) {
+	fprintf(stderr, "*** Error: a token label (-t) cannot be used to address a token for -I;\n"
+			"           use a slot index (-s) instead.\n");
+	goto err;
+    }
+
+    /* the new token label (-T) is mandatory for -I in batch mode; in interactive */
+    /* mode it is prompted for further down (see step 1).                         */
+
+    /* in batch mode, every required value must be provided up-front (safe fail). */
+    /* in interactive mode, missing values are prompted for further down.         */
+    if ( batch ) {
+	if ( sopinarg == NULL ) {
+	    fprintf(stderr, "*** Error: a SO PIN (-O) is required in batch mode.\n");
+	    goto err;
+	}
+	if ( do_inittoken ) {
+	    if ( slot < 0 ) {
+		fprintf(stderr, "*** Error: token initialization (-I) requires a slot index (-s) in batch mode.\n");
+		goto err;
+	    }
+	    if ( newlabel == NULL ) {
+		fprintf(stderr, "*** Error: token initialization (-I) requires a token label (-T) in batch mode.\n");
+		goto err;
+	    }
+	}
+	if ( do_initpin ) {
+	    if ( userpinarg == NULL ) {
+		fprintf(stderr, "*** Error: user PIN initialization (-U) requires a new user PIN (-P) in batch mode.\n");
+		goto err;
+	    }
+	    if ( !do_inittoken && slot < 0 && tokenlabel == NULL ) {
+		fprintf(stderr, "*** Error: user PIN initialization (-U) requires a slot index (-s) or a token label (-t) in batch mode.\n");
+		goto err;
+	    }
+	}
+    }
+
+    /* resolve PIN arguments (':::exec:' handling, ':::nologin' rejection). */
+    /* A NULL result means "not provided" and will be prompted for when interactive. */
+    if ( resolve_pin("the SO PIN (-O)", sopinarg, &sopin, &sopin_allocated) != 0 ) {
+	goto err;
+    }
+
+    if ( do_initpin ) {
+	if ( resolve_pin("the user PIN (-P)", userpinarg, &userpin, &userpin_allocated) != 0 ) {
+	    goto err;
+	}
+    }
+
+    /* --- proceed --- */
+
+    if ( (p11Context = pkcs11_newContext( library, nsscfgdir )) == NULL ) {
+	retcode = rc_error_library;
+	goto err;
+    }
+
+    if ( ( retcode = pkcs11_initialize( p11Context ) ) != CKR_OK ) {
+	goto err;
+    }
+
+    /* step 1: token initialization, if requested (no session must be open) */
+    if ( do_inittoken ) {
+	/* resolve the slot index, in the same fashion as the other commands:    */
+	/* when -s is given, echo the selected slot; otherwise (interactive) list */
+	/* all slots and prompt.                                                  */
+	if ( ( retcode = pkcs11_get_slotindex( p11Context, &slot, NULL, interactive ) ) != rc_ok ) {
+	    goto finalize;
+	}
+
+	/* check the chosen slot BEFORE collecting a token label / SO PIN: it must */
+	/* hold an uninitialized token, unless -R authorizes a (confirmed) reset.  */
+	if ( ( retcode = pkcs11_inittoken_guard( p11Context, slot, reset, interactive ) ) != rc_ok ) {
+	    goto finalize;
+	}
+
+	/* prompt for the new token label (-T) if it was not provided (interactive only) */
+	if ( newlabel == NULL ) {
+	    newlabel = pkcs11_prompt( NEW_LABEL_PROMPT_STRING, CK_TRUE );
+	    newlabel_allocated = 1;
+	    if ( newlabel == NULL || newlabel[0] == '\0' ) {
+		fprintf(stderr, "*** Error: a token label is required to initialize a token.\n");
+		retcode = rc_error_usage;
+		goto finalize;
+	    }
+	}
+
+	/* prompt for the SO PIN if it was not provided (interactive only).      */
+	/* this SO PIN is being DEFINED on the token, so confirm it (twice) to    */
+	/* guard against a typo.                                                  */
+	if ( sopin == NULL ) {
+	    sopin = pkcs11_prompt_new_secret( SO_PIN_PROMPT_STRING, SO_PIN_CONFIRM_PROMPT_STRING );
+	    sopin_allocated = 1;
+	    if ( sopin == NULL ) {
+		retcode = rc_error_prompt;
+		goto finalize;
+	    }
+	}
+
+	retcode = pkcs11_init_token( p11Context, slot, sopin, newlabel, reset, interactive );
+	if ( retcode != rc_ok ) {
+	    goto finalize;
+	}
+    }
+
+    /* step 2: user PIN initialization, if requested (requires an SO session) */
+    if ( do_initpin ) {
+	/* After a fresh token init, the provider may reassign slot indexes, so we */
+	/* re-address the token by the label we just set (-T) rather than by index. */
+	char * uselabel = do_inittoken ? newlabel : tokenlabel;
+	int useslot = do_inittoken ? -1 : slot;
+
+	/* resolve and display the target slot (by label or index), or, when nothing */
+	/* is specified interactively, list all slots and prompt for one.            */
+	if ( ( retcode = pkcs11_get_slotindex( p11Context, &useslot, uselabel, interactive ) ) != rc_ok ) {
+	    goto finalize;
+	}
+
+	/* for a standalone -U, ask for an explicit confirmation before (re)setting  */
+	/* the user PIN of the selected token (it may lock out its current owner).    */
+	if ( !do_inittoken && interactive ) {
+	    char * answer = pkcs11_prompt( CONFIRM_INITPIN_PROMPT_STRING, CK_TRUE );
+	    int confirmed = ( answer != NULL && tolower((unsigned char)answer[0]) == 'y' );
+	    if ( answer != NULL ) { pkcs11_prompt_free_buffer( answer ); }
+	    if ( !confirmed ) {
+		fprintf(stderr, "Aborted: the user PIN has NOT been changed.\n");
+		retcode = rc_error_other_error;
+		goto finalize;
+	    }
+	}
+
+	/* pkcs11_open_session prompts for the SO PIN (when NULL) on its own, */
+	/* mirroring the other commands. The slot has already been resolved.  */
+	retcode = pkcs11_open_session( p11Context, useslot, NULL, sopin, 1 /* SO */, interactive );
+	if ( retcode != rc_ok ) {
+	    goto finalize;
+	}
+	session_opened = 1;
+
+	retcode = pkcs11_init_pin( p11Context, userpin, interactive );
+    }
+
+    if ( session_opened ) {
+	pkcs11_close_session( p11Context );
+    }
+
+finalize:
+    pkcs11_finalize( p11Context );
+
+err:
+    if ( sopin_allocated ) { pkcs11_prompt_free_buffer(sopin); }
+    if ( userpin_allocated ) { pkcs11_prompt_free_buffer(userpin); }
+    if ( newlabel_allocated ) { pkcs11_prompt_free_buffer(newlabel); }
+    if ( p11Context ) { pkcs11_freeContext(p11Context); }
+
+    return retcode;
+}


### PR DESCRIPTION
This pull request introduces a new command, `p11init`, for initializing PKCS#11 tokens and/or their user/Security Officer PINs, and integrates it into the toolkit's documentation, build system, and shell completion scripts. It also exposes and refines several utility functions to support this new functionality. The most important changes are grouped below:

### New command: `p11init`
* Added the `p11init` command to initialize a token (`C_InitToken`), set or reset its user/Security Officer PIN (`C_InitPIN`), or reinitialize an existing token, with explicit options for batch/interactive usage and safety confirmations. (`[[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9)`, `[[2]](diffhunk://#diff-04eb6b5128a4357af0529c658dc524b2cc296dc753c736cfcf91563b48b99e13R82)`, `[[3]](diffhunk://#diff-04eb6b5128a4357af0529c658dc524b2cc296dc753c736cfcf91563b48b99e13R1026-R1143)`, `[[4]](diffhunk://#diff-4cb884d03ebb901069e4ee5de5d02538c40dd9b39919c615d8eaa9d364bbbd77L45-R45)`, `[[5]](diffhunk://#diff-da4343db487f956d94d2483e788a81e50f0afb738736af75234d90532274f6ecR23)`)

### Documentation and manual updates
* Updated `CHANGELOG.md` and `docs/MANUAL.md` to document the new `p11init` command, including its usage, options, and examples. (`[[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9)`, `[[2]](diffhunk://#diff-04eb6b5128a4357af0529c658dc524b2cc296dc753c736cfcf91563b48b99e13R82)`, `[[3]](diffhunk://#diff-04eb6b5128a4357af0529c658dc524b2cc296dc753c736cfcf91563b48b99e13R1026-R1143)`)

### Shell completion support
* Added Bash and Zsh completion scripts for `p11init`, enabling autocompletion of its options, slot indexes, and token labels. (`[[1]](diffhunk://#diff-2cd896b4ed66bb78110851ba5aa197ff335d2ee8d975713a02a4f0c4017bd889R1-R49)`, `[[2]](diffhunk://#diff-0462e381b2fb3286568215681c8983490a37ac9ae0f0c5ee304df7fa6426d4afR52)`, `[[3]](diffhunk://#diff-ae0da98c479d78ead326b2f1fa86fdf48ea2eda8d8ce62a08c786d44e133444aL1-R1)`, `[[4]](diffhunk://#diff-ae0da98c479d78ead326b2f1fa86fdf48ea2eda8d8ce62a08c786d44e133444aL22-R23)`, `[[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L339-R341)`)

### Library and API enhancements
* Exposed and documented utility functions in `pkcs11lib.h` and `pkcs11_session.c`, such as `tokenlabelcmp`, and added new functions for slot selection and token/user PIN initialization to support `p11init`. (`[[1]](diffhunk://#diff-3e4914163dc4471fded3935d4e96654ed42be346ac308a657b0466827ff6e669R413-R423)`, `[[2]](diffhunk://#diff-09c59640c5db59ab0f2bc3917b8f6f1c8f83b84cf1c3ef094e5525e0688a8898L29-R29)`, `[[3]](diffhunk://#diff-09c59640c5db59ab0f2bc3917b8f6f1c8f83b84cf1c3ef094e5525e0688a8898L75-R75)`, `[[4]](diffhunk://#diff-931d169ad902f26c93a6af265b3bbcc571a975737f85e33ce66dea285d4d2d60R63)`)
* Improved prompt utilities in `pkcs11_utils.c` by adding `pkcs11_prompt_new_secret`, allowing for secure double-entry of new PINs, and refactored prompt handling for better user interaction. (`[[1]](diffhunk://#diff-3e4914163dc4471fded3935d4e96654ed42be346ac308a657b0466827ff6e669R364)`, `[[2]](diffhunk://#diff-08b6b1ee42d9fb6797d78fe9008a65f4bd68443767022773fb4a151e0a7f8841L32-R36)`, `[[3]](diffhunk://#diff-08b6b1ee42d9fb6797d78fe9008a65f4bd68443767022773fb4a151e0a7f8841L44-R48)`, `[[4]](diffhunk://#diff-08b6b1ee42d9fb6797d78fe9008a65f4bd68443767022773fb4a151e0a7f8841R87-R97)`, `[[5]](diffhunk://#diff-08b6b1ee42d9fb6797d78fe9008a65f4bd68443767022773fb4a151e0a7f8841R106-R139)`)

These changes provide a robust and user-friendly way to initialize and manage PKCS#11 tokens directly from the toolkit, with clear documentation and improved developer ergonomics.