### PR TITLE
Refactor PKCS#11 wrapper scripts to use common logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - build now requires OpenSSL 3.0.0 or above (`libcrypto >= 3.0.0`)
 - Docker build files refactored to better support local repository builds, corporate proxies and static OpenSSL 3 fallback on older targets
+- `with_xxx` wrapper scripts refactored: all common logic now lives in a single, POSIX `/bin/sh` file (`with_pkcs11_common`) sourced by every wrapper, removing the previous `zsh` dependency. New options are available across all wrappers: `-n` (no slot / interactive selection), `-s` and `-S dest` (SHIM tracing), `-c` (create a commented `.pkcs11rc` template), `-e` (open `.pkcs11rc` in `$VISUAL`/`$EDITOR`) and `-h` (usage help). Library auto-detection now probes common system locations and the Homebrew prefix (`HOMEBREW_PREFIX`), and can be overridden with `PKCS11LIB`. The `.pkcs11rc` lookup walks up from the current directory to `$HOME`, honours a vendor-specific `.pkcs11rc.<vendor>` file in priority over the generic one, and exposes `$_p11_vendor` so a shared `.pkcs11rc` can dispatch per vendor. New wrappers `with_aws` (AWS CloudHSM) and `with_kryoptic` (Kryoptic) are provided, and `with_utimaco` now auto-detects the R3 client library (falling back to R2). The previous `SPY`/`pkcs11-spy.so` mechanism is replaced by `SHIM`/`libpkcs11shim`
 
 ### Fixed
 - small fix on with_xxx wrappers, replacing space with underscore in reply code

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,8 @@ EXTRA_DIST = \
 	with_softhsm             \
 	with_utimaco	         \
 	with_aws		 \
+	with_kryoptic		 \
+	with_pkcs11_common       \
 	docs/INSTALL.md	         \
 	docs/CONTRIBUTING.md     \
 	docs/MANUAL.md           \
@@ -87,6 +89,8 @@ install-exec-hook:
 		$(srcdir)/with_softhsm \
 		$(srcdir)/with_utimaco \
 		$(srcdir)/with_aws     \
+		$(srcdir)/with_kryoptic \
+		$(srcdir)/with_pkcs11_common \
 		$(DESTDIR)$(bindir)
 
 dist-hook:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ and `p11req`/`p11mkcert` can produce CSRs and self-signed certificates for ML-DS
 object inspection work with any OpenSSL 3.x; public key export, CSR and certificate creation require `libcrypto >= 3.5.0`.
 PQC support is enabled by default and can be turned off with `--disable-pqc`. See the [manual](docs/MANUAL.md) for details.
 
+The `with_xxx` wrapper scripts have also been overhauled. They now share a single, POSIX `/bin/sh` implementation
+(`with_pkcs11_common`, no more `zsh` dependency), automatically locate the vendor library (including the Homebrew prefix
+on macOS), and gain new options: `-c`/`-e` to create or edit a `.pkcs11rc` configuration file, `-n` for interactive slot
+selection, and `-s`/`-S` to trace PKCS\#11 calls through `libpkcs11shim`. The `.pkcs11rc` lookup now supports
+vendor-specific files (`.pkcs11rc.<vendor>`). Two new wrappers are provided, `with_aws` (AWS CloudHSM) and
+`with_kryoptic` ([Kryoptic](https://github.com/latchset/kryoptic)). See the [manual](docs/MANUAL.md) for details.
+
 ### July 2023
 
 Version 2.6 brings support for the AWS CloudHSM platform, library version 5.9.

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -156,22 +156,62 @@ command line will override the corresponding environment variable.
 
 ## wrapper scripts
 
-To facilitate setting environment variables and/or arguments, there are wrapper scripts that can be used to interface
-with the cryptographic tokens. All wrapper scripts begin with `with_` and are followed by the name of the platform. The
-following table lists existing scripts:
+To facilitate setting environment variables and/or arguments, a set of wrapper scripts is provided to interface with the
+most common cryptographic tokens. All wrapper script names begin with `with_` and are followed by the name of the
+platform; you simply prefix your `pkcs11-tools` command with the relevant wrapper, e.g. `with_softhsm p11ls`. The
+following table lists the existing scripts:
 
-| script name    | library              | equipment                                             |
-| -------------- | -------------------- | ----------------------------------------------------- |
-| `with_beid`    | `libbeidpkcs11.so`   | Belgian national electronic ID card PKCS#11 interface |
-| `with_luna`    | `libCryptoki2_64.so` | Thales (Gemalto) Safenet Luna HSM                     |
-| `with_nfast`   | `libcknfast.so`      | Entrust (nCipher) nShield HSM                         |
-| `with_nss`     | `libsoftokn3.so`     | Mozilla.org NSS soft token                            |
-| `with_softhsm` | `libsofthsm2.so`     | OpenDNSSSEC SoftHSM v2                                |
-| `with_utimaco` | `libcs_pkcs11_R2.so` | Utimaco Security Server HSM                           |
+| script name     | library                                  | equipment                                             |
+| --------------- | ---------------------------------------- | ----------------------------------------------------- |
+| `with_aws`      | `libcloudhsm_pkcs11.so`                  | AWS CloudHSM                                          |
+| `with_beid`     | `libbeidpkcs11.so`                       | Belgian national electronic ID card PKCS#11 interface |
+| `with_kryoptic` | `libkryoptic_pkcs11.so`                  | [Kryoptic](https://github.com/latchset/kryoptic) soft token |
+| `with_luna`     | `libCryptoki2_64.so`                     | Thales (Gemalto) Safenet Luna HSM                     |
+| `with_nfast`    | `libcknfast.so`                          | Entrust (nCipher) nShield HSM                         |
+| `with_nss`      | `libsoftokn3.so`                         | Mozilla.org NSS soft token                            |
+| `with_softhsm`  | `libsofthsm2.so`                         | OpenDNSSEC SoftHSM v2                                 |
+| `with_utimaco`  | `libcs_pkcs11_R3.so` / `libcs_pkcs11_R2.so` | Utimaco Security Server HSM (R3 preferred, R2 fallback) |
 
-Each wrapper script is looking for a file `.pkcs11rc` within the current directory, or within any parent directory up to
-the root. This file is sourced as a shell script; default variables defined here will override defaults from the wrapper
-script.
+On macOS, the wrappers look for the corresponding `.dylib` library (the SoftHSM2 module keeps its `.so` extension on all
+platforms, as it is a libtool module).
+
+All wrappers share a common implementation, `with_pkcs11_common`, which is sourced by each `with_xxx` script. It locates
+the vendor library, sources the configuration file (see below), handles the options and environment variables described
+here, and finally executes the requested command with the right environment in place.
+
+### library auto-detection
+
+Each wrapper knows the filename(s) of its vendor library and a list of vendor-specific directories to search. If the
+library is not found there, a set of common locations is also probed (`/usr/lib`, `/usr/lib64`, the multiarch
+`/usr/lib/<arch>-linux-gnu` directory on Linux, `/usr/local/lib`, `$HOME/.local/lib`, and their `pkcs11` subdirectories).
+When the Homebrew environment is active (i.e. `HOMEBREW_PREFIX` is set, typically through `eval "$(brew shellenv)"`),
+`$HOMEBREW_PREFIX/lib` and `$HOMEBREW_PREFIX/lib/pkcs11` are searched as well. The auto-detection can always be
+overridden by setting `PKCS11LIB` to the full path of the library.
+
+### the `.pkcs11rc` configuration file
+
+Before executing the command, each wrapper looks for a configuration file, starting in the current directory and walking
+up the directory tree until `$HOME` is reached (the search never goes above `$HOME`). The first match wins. At each
+level, a vendor-specific file `.pkcs11rc.<vendor>` (e.g. `.pkcs11rc.softhsm`, `.pkcs11rc.nss`) is looked up first, then
+the generic `.pkcs11rc`. The file is sourced as a POSIX shell script, so any variable it sets overrides the wrapper
+defaults.
+
+Because the same generic `.pkcs11rc` may be shared by several vendors, the wrapper exports `$_p11_vendor` (a short
+identifier such as `softhsm`, `nss`, `luna`, `aws`, `beid`, `kryoptic`, `nfast`, `utimaco`) so the file can dispatch on
+it:
+
+```sh
+case ${_p11_vendor:-} in
+    softhsm) SOFTHSM2_CONF=$HOME/.config/softhsm2/softhsm2.conf ;;
+    luna)    PKCS11TOKENLABEL=mytoken ;;
+    nss)     PKCS11NSSDIR=sql:$HOME/nssdb ;;
+esac
+```
+
+The fastest way to get started is to let the wrapper generate a template for you:
+
+- `with_xxx -c` creates a fully commented `.pkcs11rc` template (with all vendor sections) in the current directory.
+- `with_xxx -e` opens the `.pkcs11rc` in `$VISUAL`/`$EDITOR` (falling back to `vi`), creating it first if none is found.
 
 As an example, you could create a `.pkcs11rc` file to access your favorite SoftHSM token:
 
@@ -187,13 +227,41 @@ Then just invoke `with_softhsm` in front of your pkcs11-tools command:
 $ with_softhsm p11ls
 ```
 
-when invoking the wrapper scripts, a few environment variables may be specified:
+### options
 
-- `NOSLOT`: when set to `1`, slot or token are unset. It allows you to trigger the interactive mode (handy if you need
-  to check which slots are available)
-- `SPY`: set this value to a target log file, or to `/dev/stdout` or `/dev/stderr` to invoke `pkcs11-spy.so`, a shim
-  PKCS#11 interface that will trace calls and forward them to the library. Please refer to
-  the [OpenSC project](https://github.com/OpenSC/OpenSC) for more information about the spy module.
+Wrapper options are consumed by the wrapper itself and never reach the executed command:
+
+| option    | description                                                                                   |
+| --------- | --------------------------------------------------------------------------------------------- |
+| `-n`      | no slot: unset `PKCS11SLOT` and `PKCS11TOKENLABEL`, triggering interactive slot selection      |
+| `-s`      | SHIM mode: trace PKCS#11 calls through `libpkcs11shim`, output to `stderr`                     |
+| `-S dest` | SHIM mode: trace PKCS#11 calls through `libpkcs11shim`, output to `dest` (a file, or `/dev/stdout`) |
+| `-c`      | create a template `.pkcs11rc` in the current directory and exit                               |
+| `-e`      | open `.pkcs11rc` in `$VISUAL`/`$EDITOR` (creating it first if absent)                          |
+| `-h`      | show a usage summary and exit                                                                  |
+
+The `-s`/`-S` options (and the equivalent `SHIM` environment variable) rely on
+[`libpkcs11shim`](https://github.com/Mastercard/libpkcs11shim), a lightweight Mastercard open-source PKCS#11 shim that
+logs every call before forwarding it to the vendor library — a handy way to debug interactions with a token. Install it
+separately so the wrappers can find it.
+
+### environment variables
+
+When invoking the wrapper scripts, a few environment variables may be specified:
+
+- `PKCS11LIB`: override the auto-detected library with an explicit path.
+- `PKCS11SLOT`: slot index to use (default: `0`, unless `PKCS11TOKENLABEL` is set).
+- `PKCS11TOKENLABEL`: select the slot by token label instead of by index.
+- `PKCS11PASSWORD`: the token PIN (defaults are vendor-specific, e.g. `changeit`).
+- `PKCS11NSSDIR`: NSS database directory (NSS only; defaults to `sql:$HOME/.pki/nssdb`).
+- `NOSLOT`: when set to `1`, slot and token are unset (equivalent to `-n`). It allows you to trigger the interactive
+  mode (handy if you need to check which slots are available).
+- `NORC`: when set to `1`, skip sourcing any `.pkcs11rc` file.
+- `SHIM`: set this value to a target log file, or to `/dev/stdout` or `/dev/stderr`, to interpose
+  [`libpkcs11shim`](https://github.com/Mastercard/libpkcs11shim), a shim PKCS#11 interface that traces every call and
+  forwards it to the vendor library (equivalent to `-S dest`). `libpkcs11shim` is a separate Mastercard open-source
+  project; install it and make sure it is reachable through one of the library search paths to use the SHIM/`-s`/`-S`
+  options.
 
 example:
 

--- a/with_aws
+++ b/with_aws
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (c) 2020-2023 Mastercard
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,190 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# wrapper script for AWS CloudHSM tokens
+# see with_pkcs11_common for usage and alternate invocations
 #
-# Usage: with_xxxx p11command args... ==> execute the command using presets for the token
-#
-# each platform has its defaults.
-#
-# if not otherwise specified:
-# - default slot is set to 0 (define PKCS11SLOT or PKCS11TOKENLABEL to override)
-# - default password is generally set to 'changeit' (define PKCS11PASSWORD to override)
-#
-# You can set all the PKCS11XXXX variables in a configuration file (sourced by this script).
-# Two possibilites:
-# - $PWD/.pkcs11rc for a setup bound to a directory
-# - $HOME/.pkcs11rc for a user-wide setup
-#
-# alternate invocations:
-#
-# SHIM=/dev/stdout with_xxxx p11command args... ==> to interface with libpkcs11shim.so (github.com/Mastercard/libpkcs11shim) and print to stdout
-# SHIM=p11.log with_xxxx p11command args... ==> to interface with libpkcs11shim.so (github.com/Mastercard/libpkcs11shim) and write logs to p11.log
-# SPY=/dev/sdtout with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and print to stdout
-# SPY=p11.log with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and write logs to p11.log
-# NOSLOT with_xxxx p11command args... ==> unset slot and token variables, useful to force interactive mode
-# PKCS11TOKENLABEL="abc" with_xxxx p11command args... ==> you can set all PKCS11 variables you like,
-#                                                         including those that are vendor-specific
-#
-# Note that SPY mode does not support NSS.
+# AWS CloudHSM password format: "user:password"
 
 PKCS11PASSWORD=${PKCS11PASSWORD:-user:changeit}
 
-#specific to vendor
-PKCS11_LIBNAME=libcloudhsm_pkcs11.so
-PKCS11_LIBPATHS=( /opt/cloudhsm/lib /usr/local/lib )
-LIB_ENVVARS=()
+_p11_vendor=aws
 
-########################################################################
+# vendor-specific settings
+case $(uname -s) in
+    Darwin) PKCS11_LIBNAME=libcloudhsm_pkcs11.dylib ;;
+    *)      PKCS11_LIBNAME=libcloudhsm_pkcs11.so    ;;
+esac
+PKCS11_LIBPATHS="/opt/cloudhsm/lib"
+LIB_ENVVARS=""
 
-# find_p11_lib: a trivial function to find a library.
-function find_p11_lib()
-{
-    lib=${PKCS11_LIBNAME}
-    paths=${PKCS11_LIBPATHS[@]}
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find a configuration file, provided a file name and paths
-function find_cfg_file()
-{
-    file=$1			# file name in $1
-    paths=${@:2}		# paths is an array ($2, $3, ...)
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_shim_lib: find libpkcs11shim.so
-function find_shim_lib()
-{
-    lib=libpkcs11shim.so
-    case "$(uname -s)" in
-	*)
-	    paths=( /usr/local/lib /usr/lib )
-	    ;;
-    esac
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_spy_lib: find pkcs11-spy.so from OpenSC
-function find_spy_lib()
-{
-    lib=pkcs11-spy.so
-    paths=( /usr/lib/$(uname -m)-linux-gnu/pkcs11 /usr/lib64 /usr/local/lib /usr/local/opt/opensc/lib )
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-
-# source .pkcs11rc from local directory, and if not, from $HOME directory
-if [ -z "$NORC" ]; then
-    if [ -e ./.pkcs11rc ]; then
-	source ./.pkcs11rc
-    elif [ -e $HOME/.pkcs11rc ]; then
-	source $HOME/.pkcs11rc
-    fi
-fi
-
-################################################################################
-
-# library
-PKCS11LIB=${PKCS11LIB:-$(find_p11_lib)}
-
-if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-    echo "***Error: PKCS#11 Library not found, please set PKCS11LIB accordingly."
-    exit 1
-fi
-
-# if SHIM is set, we want to use the libpkcs11shim
-#
-if [ -n "$SHIM" ]; then
-    echo "SHIM set, trying to hook libpkcs11shim.so, output goes to $SHIM"
-    PKCS11SHIM=$PKCS11LIB
-    PKCS11SHIM_OUTPUT=$SHIM
-    PKCS11LIB=$(find_shim_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: libpkcs11shim.so Library not found, can't use SHIM option"
-	exit 1
-    fi
-elif [ -n "$SPY" ]; then
-    echo "SPY set, trying to hook pkcs11-spy.so, output goes to $SPY"
-    PKCS11SPY=$PKCS11LIB
-    PKCS11SPY_OUTPUT=$SPY
-    PKCS11LIB=$(find_spy_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: pkcs11-spy.so Library not found, can't use SPY option"
-	exit 1
-    fi
-fi
-    
-    
-#if NOSLOT is defined, or if PKCS11TOKENLABEL is defined we skip PKCS11SLOT
-#(useful for p11slotinfo invocation)
-if [ -z "$NOSLOT" -a -z "$PKCS11TOKENLABEL" ]; then
-    PKCS11SLOT=${PKCS11SLOT:-0}
-fi
-
-# also, if NOSLOT is defined, we unset PKCS11TOKENLABEL and PKCS11SLOT
-if [ -n "$NOSLOT" ]; then
-    unset PKCS11TOKENLABEL PKCS11SLOT
-fi
-
-# Note: there is no default value for PKCS11TOKENLABEL
-
-################################################################################
-variables=(PKCS11LIB PKCS11NSSDIR PKCS11SLOT PKCS11TOKENLABEL PKCS11PASSWORD \
-		     PKCS11SHIM PKCS11SHIM_OUTPUT PKCS11SPY PKCS11SPY_OUTPUT)
-
-environment=
-for v in ${variables[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-for v in ${LIB_ENVVARS[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-quoted=
-for item in "$@"; do
-    quoted+=($(printf "%q" "$item"))
-done
-
-eval ${environment[@]} ${quoted[@]}
-exit $?
+# load common logic
+. "$(dirname "$0")/with_pkcs11_common" "$@"

--- a/with_beid
+++ b/with_beid
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (c) 2020 Mastercard
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,198 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# wrapper script for Belgian eID (libbeidpkcs11) tokens
+# see with_pkcs11_common for usage and alternate invocations
 #
-# Usage: with_xxxx p11command args... ==> execute the command using presets for the token
-#
-# each platform has its defaults.
-#
-# if not otherwise specified:
-# - default slot is set to 0 (define PKCS11SLOT or PKCS11TOKENLABEL to override)
-# - default password is generally set to 'changeit' (define PKCS11PASSWORD to override)
-#
-# You can set all the PKCS11XXXX variables in a configuration file (sourced by this script).
-# Two possibilites:
-# - $PWD/.pkcs11rc for a setup bound to a directory
-# - $HOME/.pkcs11rc for a user-wide setup
-#
-# alternate invocations:
-#
-# SPY=/dev/sdtout with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and print to stdout
-# SPY=p11.log with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and write logs to p11.log
-# NOSLOT with_xxxx p11command args... ==> unset slot and token variables, useful to force interactive mode
-# PKCS11TOKENLABEL="abc" with_xxxx p11command args... ==> you can set all PKCS11 variables you like,
-#                                                         including those that are vendor-specific
-#
-# Note that SPY mode does not support NSS.
+# Note: Belgian eID does not use a PIN (card PIN is entered via a card reader).
 
 PKCS11SLOT=0
 # no PKCS11PASSWORD set
 
-#specific to vendor
+_p11_vendor=beid
+
+# vendor-specific settings
 case $(uname -s) in
-    Darwin)
-	PKCS11_LIBNAME=libbeidpkcs11.dylib
-	;;
-    *)
-	PKCS11_LIBNAME=libbeidpkcs11.so
-	;;
+    Darwin) PKCS11_LIBNAME=libbeidpkcs11.dylib ;;
+    *)      PKCS11_LIBNAME=libbeidpkcs11.so    ;;
 esac
-PKCS11_LIBPATHS=( /usr/lib /usr/lib/$(uname -m)-linux-gnu /usr/local/lib /usr/local/lib/pkcs11 )
+PKCS11_LIBPATHS=""
+LIB_ENVVARS=""
 
-LIB_ENVVARS=()
-
-########################################################################
-
-# find_p11_lib: a trivial function to find a library.
-function find_p11_lib()
-{
-    lib=${PKCS11_LIBNAME}
-    paths=${PKCS11_LIBPATHS[@]}
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find a configuration file, provided a file name and paths
-function find_cfg_file()
-{
-    file=$1			# file name in $1
-    paths=${@:2}		# paths is an array ($2, $3, ...)
-    
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_shim_lib: find libpkcs11shim.so
-function find_shim_lib()
-{
-    lib=libpkcs11shim.so
-    case "$(uname -s)" in
-	*)
-	    paths=( /usr/local/lib /usr/lib )
-	    ;;
-    esac
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_spy_lib: find pkcs11-spy.so from OpenSC
-function find_spy_lib()
-{
-    lib=pkcs11-spy.so
-    paths=( /usr/lib/$(uname -m)-linux-gnu/pkcs11 /usr/lib64 /usr/local/lib /usr/local/opt/opensc/lib )
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-
-# source .pkcs11rc from local directory, and if not, from $HOME directory
-if [ -z "$NORC" ]; then
-    if [ -e ./.pkcs11rc ]; then
-	source ./.pkcs11rc
-    elif [ -e $HOME/.pkcs11rc ]; then
-	source $HOME/.pkcs11rc
-    fi
-fi
-
-################################################################################
-
-# library
-PKCS11LIB=${PKCS11LIB:-$(find_p11_lib)}
-
-if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-    echo "***Error: PKCS#11 Library not found, please set PKCS11LIB accordingly."
-    exit 1
-fi
-
-# if SHIM is set, we want to use the libpkcs11shim
-#
-if [ -n "$SHIM" ]; then
-    echo "SHIM set, trying to hook libpkcs11shim.so, output goes to $SHIM"
-    PKCS11SHIM=$PKCS11LIB
-    PKCS11SHIM_OUTPUT=$SHIM
-    PKCS11LIB=$(find_shim_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: libpkcs11shim.so Library not found, can't use SHIM option"
-	exit 1
-    fi
-elif [ -n "$SPY" ]; then
-    echo "SPY set, trying to hook pkcs11-spy.so, output goes to $SPY"
-    PKCS11SPY=$PKCS11LIB
-    PKCS11SPY_OUTPUT=$SPY
-    PKCS11LIB=$(find_spy_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: pkcs11-spy.so Library not found, can't use SPY option"
-	exit 1
-    fi
-fi
-    
-    
-#if NOSLOT is defined, or if PKCS11TOKENLABEL is defined we skip PKCS11SLOT
-#(useful for p11slotinfo invocation)
-if [ -z "$NOSLOT" -a -z "$PKCS11TOKENLABEL" ]; then
-    PKCS11SLOT=${PKCS11SLOT:-0}
-fi
-
-# also, if NOSLOT is defined, we unset PKCS11TOKENLABEL and PKCS11SLOT
-if [ -n "$NOSLOT" ]; then
-    unset PKCS11TOKENLABEL PKCS11SLOT
-fi
-
-# Note: there is no default value for PKCS11TOKENLABEL
-
-################################################################################
-variables=(PKCS11LIB PKCS11NSSDIR PKCS11SLOT PKCS11TOKENLABEL PKCS11PASSWORD \
-		     PKCS11SHIM PKCS11SHIM_OUTPUT PKCS11SPY PKCS11SPY_OUTPUT)
-
-environment=
-for v in ${variables[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-for v in ${LIB_ENVVARS[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-quoted=
-for item in "$@"; do
-    quoted+=($(printf "%q" "$item"))
-done
-
-eval ${environment[@]} ${quoted[@]}
-exit $?
-
+# load common logic
+. "$(dirname "$0")/with_pkcs11_common" "$@"

--- a/with_kryoptic
+++ b/with_kryoptic
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Copyright (c) 2020 Mastercard
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# wrapper script for Kryoptic tokens (https://github.com/latchset/kryoptic)
+# see with_pkcs11_common for usage and alternate invocations
+#
+# Kryoptic-specific notes:
+#   - library: libkryoptic_pkcs11.so (.dylib on macOS)
+#   - KRYOPTIC_CONF: path to the TOML configuration file (highest precedence)
+#   - if KRYOPTIC_CONF is not set, falls back to:
+#       ${XDG_CONFIG_HOME}/kryoptic/token.conf  or
+#       ${HOME}/.config/kryoptic/token.conf
+
+PKCS11PASSWORD=${PKCS11PASSWORD:-changeit}
+
+_p11_vendor=kryoptic
+
+# vendor-specific settings
+case $(uname -s) in
+    Darwin) PKCS11_LIBNAME=libkryoptic_pkcs11.dylib ;;
+    *)      PKCS11_LIBNAME=libkryoptic_pkcs11.so    ;;
+esac
+PKCS11_LIBPATHS=""
+LIB_ENVVARS="KRYOPTIC_CONF"
+
+# set KRYOPTIC_CONF to the default location if not already set and the file exists
+if [ -z "${KRYOPTIC_CONF:-}" ]; then
+    _default_conf="${XDG_CONFIG_HOME:-$HOME/.config}/kryoptic/token.conf"
+    if [ -e "$_default_conf" ]; then
+        KRYOPTIC_CONF="$_default_conf"
+    fi
+    unset _default_conf
+fi
+
+# load common logic
+. "$(dirname "$0")/with_pkcs11_common" "$@"

--- a/with_luna
+++ b/with_luna
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (c) 2020 Mastercard
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,203 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
-# Usage: with_xxxx p11command args... ==> execute the command using presets for the token
-#
-# each platform has its defaults.
-#
-# if not otherwise specified:
-# - default slot is set to 0 (define PKCS11SLOT or PKCS11TOKENLABEL to override)
-# - default password is generally set to 'changeit' (define PKCS11PASSWORD to override)
-#
-# You can set all the PKCS11XXXX variables in a configuration file (sourced by this script).
-# Two possibilites:
-# - $PWD/.pkcs11rc for a setup bound to a directory
-# - $HOME/.pkcs11rc for a user-wide setup
-#
-# alternate invocations:
-#
-# SPY=/dev/sdtout with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and print to stdout
-# SPY=p11.log with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and write logs to p11.log
-# NOSLOT with_xxxx p11command args... ==> unset slot and token variables, useful to force interactive mode
-# PKCS11TOKENLABEL="abc" with_xxxx p11command args... ==> you can set all PKCS11 variables you like,
-#                                                         including those that are vendor-specific
-#
-# Note that SPY mode does not support NSS.
+# wrapper script for SafeNet Luna tokens
+# see with_pkcs11_common for usage and alternate invocations
 
 PKCS11PASSWORD=${PKCS11PASSWORD:-changeit}
 
-#specific to vendor
-PKCS11_LIBNAME=libCryptoki2_64.so
-PKCS11_LIBPATHS=(/usr/lib /usr/safenet/lunaclient/lib /opt/safenet/lunaclient/lib)
-LIB_ENVVARS=()
+_p11_vendor=luna
 
-########################################################################
+# vendor-specific settings
+case $(uname -s) in
+    Darwin) PKCS11_LIBNAME=libCryptoki2_64.dylib ;;
+    *)      PKCS11_LIBNAME=libCryptoki2_64.so    ;;
+esac
+PKCS11_LIBPATHS="/usr/safenet/lunaclient/lib /opt/safenet/lunaclient/lib"
+LIB_ENVVARS=""
 
-# find_p11_lib: a trivial function to find a library.
-function find_p11_lib()
-{
-    lib=${PKCS11_LIBNAME}
-    paths=${PKCS11_LIBPATHS[@]}
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find a configuration file, provided a file name and paths
-function find_cfg_file()
-{
-    file=$1			# file name in $1
-    paths=${@:2}		# paths is an array ($2, $3, ...)
-    
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_shim_lib: find libpkcs11shim.so
-function find_shim_lib()
-{
-    lib=libpkcs11shim.so
-    case "$(uname -s)" in
-	*)
-	    paths=( /usr/local/lib /usr/lib )
-	    ;;
-    esac
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_spy_lib: find pkcs11-spy.so from OpenSC
-function find_spy_lib()
-{
-    lib=pkcs11-spy.so
-    paths=( /usr/lib/$(uname -m)-linux-gnu/pkcs11 /usr/lib64 /usr/local/lib /usr/local/opt/opensc/lib )
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-function find_spy_lib()
-{
-    lib=pkcs11-spy.so
-    paths=( /usr/lib/$(uname -m)-linux-gnu/pkcs11 /usr/lib64 /usr/local/lib /usr/local/opt/opensc/lib )
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-
-# source .pkcs11rc from local directory, and if not, from $HOME directory
-if [ -z "$NORC" ]; then
-    if [ -e ./.pkcs11rc ]; then
-	source ./.pkcs11rc
-    elif [ -e $HOME/.pkcs11rc ]; then
-	source $HOME/.pkcs11rc
-    fi
-fi
-
-################################################################################
-
-# library
-PKCS11LIB=${PKCS11LIB:-$(find_p11_lib)}
-
-if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-    echo "***Error: PKCS#11 Library not found, please set PKCS11LIB accordingly."
-    exit 1
-fi
-
-# if SHIM is set, we want to use the libpkcs11shim
-#
-if [ -n "$SHIM" ]; then
-    echo "SHIM set, trying to hook libpkcs11shim.so, output goes to $SHIM"
-    PKCS11SHIM=$PKCS11LIB
-    PKCS11SHIM_OUTPUT=$SHIM
-    PKCS11LIB=$(find_shim_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: libpkcs11shim.so Library not found, can't use SHIM option"
-	exit 1
-    fi
-elif [ -n "$SPY" ]; then
-    echo "SPY set, trying to hook pkcs11-spy.so, output goes to $SPY"
-    PKCS11SPY=$PKCS11LIB
-    PKCS11SPY_OUTPUT=$SPY
-    PKCS11LIB=$(find_spy_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: pkcs11-spy.so Library not found, can't use SPY option"
-	exit 1
-    fi
-fi
-    
-    
-#if NOSLOT is defined, or if PKCS11TOKENLABEL is defined we skip PKCS11SLOT
-#(useful for p11slotinfo invocation)
-if [ -z "$NOSLOT" -a -z "$PKCS11TOKENLABEL" ]; then
-    PKCS11SLOT=${PKCS11SLOT:-0}
-fi
-
-# also, if NOSLOT is defined, we unset PKCS11TOKENLABEL and PKCS11SLOT
-if [ -n "$NOSLOT" ]; then
-    unset PKCS11TOKENLABEL PKCS11SLOT
-fi
-
-# Note: there is no default value for PKCS11TOKENLABEL
-
-################################################################################
-variables=(PKCS11LIB PKCS11NSSDIR PKCS11SLOT PKCS11TOKENLABEL PKCS11PASSWORD \
-		     PKCS11SHIM PKCS11SHIM_OUTPUT PKCS11SPY PKCS11SPY_OUTPUT)
-
-environment=
-for v in ${variables[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-for v in ${LIB_ENVVARS[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-quoted=
-for item in "$@"; do
-    quoted+=($(printf "%q" "$item"))
-done
-
-eval ${environment[@]} ${quoted[@]}
-exit $?
+# load common logic
+. "$(dirname "$0")/with_pkcs11_common" "$@"

--- a/with_nfast
+++ b/with_nfast
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (c) 2020 Mastercard
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,37 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# wrapper script for Entrust nFast/nShield tokens
+# see with_pkcs11_common for usage and alternate invocations
 #
-# Usage: with_xxxx p11command args... ==> execute the command using presets for the token
-#
-# each platform has its defaults.
-#
-# if not otherwise specified:
-# - default slot is set to 0 (define PKCS11SLOT or PKCS11TOKENLABEL to override)
-# - default password is generally set to 'changeit' (define PKCS11PASSWORD to override)
-#
-# You can set all the PKCS11XXXX variables in a configuration file (sourced by this script).
-# Two possibilites:
-# - $PWD/.pkcs11rc for a setup bound to a directory
-# - $HOME/.pkcs11rc for a user-wide setup
-#
-# alternate invocations:
-#
-# SPY=/dev/sdtout with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and print to stdout
-# SPY=p11.log with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and write logs to p11.log
-# NOSLOT with_xxxx p11command args... ==> unset slot and token variables, useful to force interactive mode
-# PKCS11TOKENLABEL="abc" with_xxxx p11command args... ==> you can set all PKCS11 variables you like,
-#                                                         including those that are vendor-specific
-#
-# Note that SPY mode does not support NSS.
+# nFast-specific notes:
+#   - slot 1 is used (OCS is the second slot, after the accelerator slot)
+#   - CKNFAST_LOADSHARING and CKNFAST_FAKE_ACCELERATOR_LOGIN are set for typical use
+#   - uncomment CKNFAST_DEBUG / CKNFAST_DEBUGDIR for troubleshooting
 
 PKCS11SLOT=1			# OCS is the second slot, after accelerator slot
 PKCS11PASSWORD=${PKCS11PASSWORD:-changeit}
 
-#specific to vendor
-PKCS11_LIBNAME=libcknfast.so
-PKCS11_LIBPATHS=( /opt/nfast/toolkits/pkcs11 )
-LIB_ENVVARS=(CKNFAST_LOADSHARING CKNFAST_FAKE_ACCELERATOR_LOGIN CKNFAST_DEBUG CKNFAST_DEBUGDIR CKNFAST_OVERRIDE_SECURITY_ASSURANCES)
+_p11_vendor=nfast
+
+# vendor-specific settings
+case $(uname -s) in
+    Darwin) PKCS11_LIBNAME=libcknfast.dylib ;;
+    *)      PKCS11_LIBNAME=libcknfast.so    ;;
+esac
+PKCS11_LIBPATHS="/opt/nfast/toolkits/pkcs11"
+LIB_ENVVARS="CKNFAST_LOADSHARING CKNFAST_FAKE_ACCELERATOR_LOGIN CKNFAST_DEBUG CKNFAST_DEBUGDIR CKNFAST_OVERRIDE_SECURITY_ASSURANCES"
 
 CKNFAST_LOADSHARING=1
 CKNFAST_FAKE_ACCELERATOR_LOGIN=1
@@ -51,157 +40,5 @@ CKNFAST_FAKE_ACCELERATOR_LOGIN=1
 # CKNFAST_DEBUGDIR=/var/tmp
 # CKNFAST_OVERRIDE_SECURITY_ASSURANCES=all
 
-########################################################################
-
-# find_p11_lib: a trivial function to find a library.
-function find_p11_lib()
-{
-    lib=${PKCS11_LIBNAME}
-    paths=${PKCS11_LIBPATHS[@]}
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find a configuration file, provided a file name and paths
-function find_cfg_file()
-{
-    file=$1			# file name in $1
-    paths=${@:2}		# paths is an array ($2, $3, ...)
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_shim_lib: find libpkcs11shim.so
-function find_shim_lib()
-{
-    lib=libpkcs11shim.so
-    case "$(uname -s)" in
-	*)
-	    paths=( /usr/local/lib /usr/lib )
-	    ;;
-    esac
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_spy_lib: find pkcs11-spy.so from OpenSC
-function find_spy_lib()
-{
-    lib=pkcs11-spy.so
-    paths=( /usr/lib/$(uname -m)-linux-gnu/pkcs11 /usr/lib64 /usr/local/lib /usr/local/opt/opensc/lib )
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-
-# source .pkcs11rc from local directory, and if not, from $HOME directory
-if [ -z "$NORC" ]; then
-    if [ -e ./.pkcs11rc ]; then
-	source ./.pkcs11rc
-    elif [ -e $HOME/.pkcs11rc ]; then
-	source $HOME/.pkcs11rc
-    fi
-fi
-
-################################################################################
-
-# library
-PKCS11LIB=${PKCS11LIB:-$(find_p11_lib)}
-
-if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-    echo "***Error: PKCS#11 Library not found, please set PKCS11LIB accordingly."
-    exit 1
-fi
-
-# if SHIM is set, we want to use the libpkcs11shim
-#
-if [ -n "$SHIM" ]; then
-    echo "SHIM set, trying to hook libpkcs11shim.so, output goes to $SHIM"
-    PKCS11SHIM=$PKCS11LIB
-    PKCS11SHIM_OUTPUT=$SHIM
-    PKCS11LIB=$(find_shim_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: libpkcs11shim.so Library not found, can't use SHIM option"
-	exit 1
-    fi
-elif [ -n "$SPY" ]; then
-    echo "SPY set, trying to hook pkcs11-spy.so, output goes to $SPY"
-    PKCS11SPY=$PKCS11LIB
-    PKCS11SPY_OUTPUT=$SPY
-    PKCS11LIB=$(find_spy_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: pkcs11-spy.so Library not found, can't use SPY option"
-	exit 1
-    fi
-fi
-    
-    
-#if NOSLOT is defined, or if PKCS11TOKENLABEL is defined we skip PKCS11SLOT
-#(useful for p11slotinfo invocation)
-if [ -z "$NOSLOT" -a -z "$PKCS11TOKENLABEL" ]; then
-    PKCS11SLOT=${PKCS11SLOT:-0}
-fi
-
-# also, if NOSLOT is defined, we unset PKCS11TOKENLABEL and PKCS11SLOT
-if [ -n "$NOSLOT" ]; then
-    unset PKCS11TOKENLABEL PKCS11SLOT
-fi
-
-# Note: there is no default value for PKCS11TOKENLABEL
-
-################################################################################
-variables=(PKCS11LIB PKCS11NSSDIR PKCS11SLOT PKCS11TOKENLABEL PKCS11PASSWORD \
-		     PKCS11SHIM PKCS11SHIM_OUTPUT PKCS11SPY PKCS11SPY_OUTPUT)
-
-environment=
-for v in ${variables[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-for v in ${LIB_ENVVARS[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-quoted=
-for item in "$@"; do
-    quoted+=($(printf "%q" "$item"))
-done
-
-eval ${environment[@]} ${quoted[@]}
-exit $?
+# load common logic
+. "$(dirname "$0")/with_pkcs11_common" "$@"

--- a/with_nss
+++ b/with_nss
@@ -44,7 +44,7 @@ PKCS11NSSDIR=${PKCS11NSSDIR:-sql:$HOME/.pki/nssdb}
 # early rather than letting NSS silently operate on a missing/unexpected path.
 p11_post_rc()
 {
-    NSS_LIB_PARAMS=${NSS_LIB_PARAMS:-configDir=\'${PKCS11NSSDIR}\'}
+    NSS_LIB_PARAMS=${NSS_LIB_PARAMS:-"configDir='${PKCS11NSSDIR}'"}
 
     # Strip a leading database-type prefix ("sql:", "dbm:", ...) to get the path.
     _nssdir=${PKCS11NSSDIR#*:}

--- a/with_nss
+++ b/with_nss
@@ -44,17 +44,37 @@ PKCS11NSSDIR=${PKCS11NSSDIR:-sql:$HOME/.pki/nssdb}
 # early rather than letting NSS silently operate on a missing/unexpected path.
 p11_post_rc()
 {
+    # Pick the NSS_LIB_PARAMS NSS will actually use: an explicit value (from the
+    # environment or .pkcs11rc) wins; otherwise derive one from PKCS11NSSDIR.
     NSS_LIB_PARAMS=${NSS_LIB_PARAMS:-"configDir='${PKCS11NSSDIR}'"}
 
-    # Strip a leading database-type prefix ("sql:", "dbm:", ...) to get the path.
-    _nssdir=${PKCS11NSSDIR#*:}
-    if [ ! -d "$_nssdir" ]; then
-        echo "***Error: NSS database directory '$_nssdir' does not exist (PKCS11NSSDIR='$PKCS11NSSDIR')." >&2
-        echo "          Create it first, e.g.:  mkdir -p '$_nssdir' && certutil -N -d 'sql:$_nssdir'" >&2
-        echo "          or set PKCS11NSSDIR in .pkcs11rc to an existing database directory." >&2
-        exit 1
-    fi
-    unset _nssdir
+    # Verify that the NSS database directory exists, failing early rather than
+    # letting NSS silently operate on a missing/unexpected path.  Take the path
+    # from the effective NSS_LIB_PARAMS' configDir so the check follows an
+    # explicit NSS_LIB_PARAMS, not just the PKCS11NSSDIR default it may have
+    # overridden.  When NSS_LIB_PARAMS carries no configDir, NSS falls back to
+    # its own default and there is nothing here for us to validate.
+    case "$NSS_LIB_PARAMS" in
+        configDir=*|*[!_a-zA-Z0-9]configDir=*)
+            _nssdir=${NSS_LIB_PARAMS#*configDir=}
+            # The value may be single-quoted, double-quoted, or bare (ending at
+            # the next space); keep just the value.
+            case "$_nssdir" in
+                \'*) _nssdir=${_nssdir#\'}; _nssdir=${_nssdir%%\'*} ;;
+                \"*) _nssdir=${_nssdir#\"}; _nssdir=${_nssdir%%\"*} ;;
+                *)    _nssdir=${_nssdir%% *} ;;
+            esac
+            # Strip a leading database-type prefix ("sql:", "dbm:", ...).
+            _nssdir=${_nssdir#*:}
+            if [ -n "$_nssdir" ] && [ ! -d "$_nssdir" ]; then
+                echo "***Error: NSS database directory '$_nssdir' does not exist (NSS_LIB_PARAMS='$NSS_LIB_PARAMS')." >&2
+                echo "          Create it first, e.g.:  mkdir -p '$_nssdir' && certutil -N -d 'sql:$_nssdir'" >&2
+                echo "          or set PKCS11NSSDIR (or NSS_LIB_PARAMS) to an existing database directory." >&2
+                exit 1
+            fi
+            unset _nssdir
+            ;;
+    esac
 }
 
 _p11_vendor=nss

--- a/with_nss
+++ b/with_nss
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (c) 2020 Mastercard
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,204 +13,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# wrapper script for NSS (softokn3) tokens
+# see with_pkcs11_common for usage and alternate invocations
 #
-# Usage: with_xxxx p11command args... ==> execute the command using presets for the token
-#
-# each platform has its defaults.
-#
-# if not otherwise specified:
-# - default slot is set to 0 (define PKCS11SLOT or PKCS11TOKENLABEL to override)
-# - default password is generally set to 'changeit' (define PKCS11PASSWORD to override)
-#
-# You can set all the PKCS11XXXX variables in a configuration file (sourced by this script).
-# Two possibilites:
-# - $PWD/.pkcs11rc for a setup bound to a directory
-# - $HOME/.pkcs11rc for a user-wide setup
-#
-# alternate invocations:
-#
-# SPY=/dev/sdtout with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and print to stdout
-# SPY=p11.log with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and write logs to p11.log
-# NOSLOT with_xxxx p11command args... ==> unset slot and token variables, useful to force interactive mode
-# PKCS11TOKENLABEL="abc" with_xxxx p11command args... ==> you can set all PKCS11 variables you like,
-#                                                         including those that are vendor-specific
-#
-# Note that SPY mode does not support NSS.
+# NSS-specific notes:
+#   - slot 1 is used (slot 0 is the NSS internal slot)
+#   - PKCS11NSSDIR points to the NSS *database* directory (not the library),
+#     defaulting to the conventional per-user NSS DB sql:$HOME/.pki/nssdb.
+#     Set it in .pkcs11rc (or the environment) to use a different location.
+#   - to create an NSS token: modutil -dbdir sql:. -create
+#                              modutil -dbdir sql:. -changepw "NSS Certificate DB"
+#   - NSS_LIB_PARAMS is forwarded to the command if set
 
 PKCS11SLOT=1
-PKCS11PASSWORD=${PKCS11PASSWORD:-changeit}
-# by default, we are looking for an NSS db inside the current directory
-PKCS11NSSDIR=sql:.
+# The password is a bit different than usual, this one should satisfy password complexity requirements
+PKCS11PASSWORD=${PKCS11PASSWORD:-ch@nge1t}
+# Default NSS database directory: the conventional per-user NSS DB
+# ($HOME/.pki/nssdb), where Chrome/Chromium, p11-kit, etc. keep the user
+# database.  We deliberately do NOT fall back to the current directory ("sql:."),
+# which would be surprising and risky; set PKCS11NSSDIR in .pkcs11rc (or the
+# environment) to use a different location.
+PKCS11NSSDIR=${PKCS11NSSDIR:-sql:$HOME/.pki/nssdb}
 
-# to create your NSS token:
-# $ modutil -dbdir sql:. -create
-# $ modutil -dbdir sql:. -changepw "NSS Certificate DB"
+# On newer NSS versions, NSS_LIB_PARAMS can be used instead of PKCS11NSSDIR, and
+# can contain additional parameters (e.g. "configDir='sql:.'").
+# It is derived from PKCS11NSSDIR *after* .pkcs11rc has been sourced (via the
+# p11_post_rc hook in with_pkcs11_common), so that overriding PKCS11NSSDIR in
+# .pkcs11rc is reflected here.  An explicit NSS_LIB_PARAMS still takes precedence.
+# The same hook also verifies that the NSS database directory exists, failing
+# early rather than letting NSS silently operate on a missing/unexpected path.
+p11_post_rc()
+{
+    NSS_LIB_PARAMS=${NSS_LIB_PARAMS:-configDir=\'${PKCS11NSSDIR}\'}
 
-#specific to vendor
+    # Strip a leading database-type prefix ("sql:", "dbm:", ...) to get the path.
+    _nssdir=${PKCS11NSSDIR#*:}
+    if [ ! -d "$_nssdir" ]; then
+        echo "***Error: NSS database directory '$_nssdir' does not exist (PKCS11NSSDIR='$PKCS11NSSDIR')." >&2
+        echo "          Create it first, e.g.:  mkdir -p '$_nssdir' && certutil -N -d 'sql:$_nssdir'" >&2
+        echo "          or set PKCS11NSSDIR in .pkcs11rc to an existing database directory." >&2
+        exit 1
+    fi
+    unset _nssdir
+}
+
+_p11_vendor=nss
+
+# vendor-specific settings
 case $(uname -s) in
-    Darwin)
-	PKCS11_LIBNAME=libsoftokn3.dylib
-	;;
-    *)
-	PKCS11_LIBNAME=libsoftokn3.so
-	;;
+    Darwin) PKCS11_LIBNAME=libsoftokn3.dylib ;;
+    *)      PKCS11_LIBNAME=libsoftokn3.so    ;;
 esac
-PKCS11_LIBPATHS=( /usr/lib /usr/lib/$(uname -m)-linux-gnu/nss /usr/lib64 /usr/local/lib /usr/local/opt/nss/lib )
+PKCS11_LIBPATHS="/usr/lib/$(uname -m)-linux-gnu/nss /usr/local/opt/nss/lib"
+LIB_ENVVARS="NSS_LIB_PARAMS"
 
-LIB_ENVVARS=()
-
-########################################################################
-
-# find_p11_lib: a trivial function to find a library.
-function find_p11_lib()
-{
-    lib=${PKCS11_LIBNAME}
-    paths=${PKCS11_LIBPATHS[@]}
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find a configuration file, provided a file name and paths
-function find_cfg_file()
-{
-    file=$1			# file name in $1
-    paths=${@:2}		# paths is an array ($2, $3, ...)
-    
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_shim_lib: find libpkcs11shim.so
-function find_shim_lib()
-{
-    lib=libpkcs11shim.so
-    case "$(uname -s)" in
-	*)
-	    paths=( /usr/local/lib /usr/lib )
-	    ;;
-    esac
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_spy_lib: find pkcs11-spy.so from OpenSC
-function find_spy_lib()
-{
-    lib=pkcs11-spy.so
-    paths=( /usr/lib/$(uname -m)-linux-gnu/pkcs11 /usr/lib64 /usr/local/lib /usr/local/opt/opensc/lib )
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-
-# source .pkcs11rc from local directory, and if not, from $HOME directory
-if [ -z "$NORC" ]; then
-    if [ -e ./.pkcs11rc ]; then
-	source ./.pkcs11rc
-    elif [ -e $HOME/.pkcs11rc ]; then
-	source $HOME/.pkcs11rc
-    fi
-fi
-
-################################################################################
-
-# library
-PKCS11LIB=${PKCS11LIB:-$(find_p11_lib)}
-
-if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-    echo "***Error: PKCS#11 Library not found, please set PKCS11LIB accordingly."
-    exit 1
-fi
-
-# if SHIM is set, we want to use the libpkcs11shim
-#
-if [ -n "$SHIM" ]; then
-    echo "SHIM set, trying to hook libpkcs11shim.so, output goes to $SHIM"
-    PKCS11SHIM=$PKCS11LIB
-    PKCS11SHIM_OUTPUT=$SHIM
-    PKCS11LIB=$(find_shim_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: libpkcs11shim.so Library not found, can't use SHIM option"
-	exit 1
-    fi
-elif [ -n "$SPY" ]; then
-    echo "SPY set, trying to hook pkcs11-spy.so, output goes to $SPY"
-    PKCS11SPY=$PKCS11LIB
-    PKCS11SPY_OUTPUT=$SPY
-    PKCS11LIB=$(find_spy_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: pkcs11-spy.so Library not found, can't use SPY option"
-	exit 1
-    fi
-fi
-    
-    
-#if NOSLOT is defined, or if PKCS11TOKENLABEL is defined we skip PKCS11SLOT
-#(useful for p11slotinfo invocation)
-if [ -z "$NOSLOT" -a -z "$PKCS11TOKENLABEL" ]; then
-    PKCS11SLOT=${PKCS11SLOT:-0}
-fi
-
-# also, if NOSLOT is defined, we unset PKCS11TOKENLABEL and PKCS11SLOT
-if [ -n "$NOSLOT" ]; then
-    unset PKCS11TOKENLABEL PKCS11SLOT
-fi
-
-# Note: there is no default value for PKCS11TOKENLABEL
-
-################################################################################
-variables=(PKCS11LIB PKCS11NSSDIR PKCS11SLOT PKCS11TOKENLABEL PKCS11PASSWORD \
-		     PKCS11SHIM PKCS11SHIM_OUTPUT PKCS11SPY PKCS11SPY_OUTPUT)
-
-environment=
-for v in ${variables[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-for v in ${LIB_ENVVARS[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-quoted=
-for item in "$@"; do
-    quoted+=($(printf "%q" "$item"))
-done
-
-eval ${environment[@]} ${quoted[@]}
-exit $?
-
+# load common logic
+. "$(dirname "$0")/with_pkcs11_common" "$@"

--- a/with_pkcs11_common
+++ b/with_pkcs11_common
@@ -1,0 +1,443 @@
+# Copyright (c) 2020 Mastercard
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# with_pkcs11_common: common code sourced by all with_xxx wrapper scripts.
+#
+# Expected variables set by the caller before sourcing this file:
+#   PKCS11_LIBNAME       - library filename (e.g. libsofthsm2.so)
+#   PKCS11_LIBPATHS      - space-separated directories to search first
+#   LIB_ENVVARS          - space-separated env var names to forward
+#   _p11_vendor         - short vendor identifier (e.g. softhsm, luna, nss).
+#                          Set by each with_xxx wrapper. Used to:
+#                            1) load .pkcs11rc.<vendor> in priority over .pkcs11rc
+#                            2) dispatch inside .pkcs11rc via: case $_p11_vendor in
+#
+# Optional variables set by the caller:
+#   PKCS11PASSWORD       - token password (default: 'changeit')
+#   PKCS11SLOT           - slot number (default: 0 unless PKCS11TOKENLABEL is set)
+#   PKCS11NSSDIR         - NSS database directory (only needed for NSS tokens)
+#
+# Alternate invocations (set before calling the wrapper):
+#
+#   SHIM=/dev/stdout with_xxx cmd args...
+#       Route traffic through libpkcs11shim.so and print to stdout.
+#   SHIM=p11.log with_xxx cmd args...
+#       Route traffic through libpkcs11shim.so and write logs to p11.log.
+#   NOSLOT=1 with_xxx cmd args...
+#       Unset slot/token variables (force interactive slot selection).
+#   NORC=1 with_xxx cmd args...
+#       Skip sourcing any .pkcs11rc file.
+#   PKCS11TOKENLABEL="abc" with_xxx cmd args...
+#       Use token label instead of slot number.
+#   with_xxx -c
+#       Create a template .pkcs11rc in the current directory, with all vendor
+#       variables present but commented out.  Exits immediately.
+#   with_xxx -e
+#       Open .pkcs11rc in $VISUAL / $EDITOR (fallback: vi).  If no .pkcs11rc
+#       is found walking up from CWD to $HOME, creates one first.
+#   with_xxx -n cmd args...
+#       Force interactive slot selection (equivalent to NOSLOT=1).
+#   with_xxx -s cmd args...
+#       Enable SHIM mode; shim output goes to /dev/stderr.
+#   with_xxx -S dest cmd args...
+#       Enable SHIM mode; shim output goes to dest (file or /dev/stdout).
+#
+# .pkcs11rc lookup order (first match wins, walks up from CWD to $HOME):
+#   .pkcs11rc.<vendor>   - vendor-specific file (when _p11_vendor is set)
+#   .pkcs11rc            - generic file; use 'case $_p11_vendor in' to dispatch
+#
+# Example .pkcs11rc:
+#   case ${_p11_vendor:-} in
+#       softhsm) SOFTHSM2_CONF=$HOME/.config/softhsm2/softhsm2.conf ;;
+#       luna)    PKCS11TOKENLABEL=mytoken ;;
+#       nss)     PKCS11NSSDIR=sql:$HOME/nssdb ;;
+#   esac
+
+########################################################################
+
+# build_p11_libpaths: output unique search paths with defaults appended last.
+# Order is:
+#   1) vendor-defined PKCS11_LIBPATHS
+#   2) Homebrew prefix (if HOMEBREW_PREFIX is set in the environment)
+#   3) shared fallback paths (Linux-only triplet path included on Linux)
+p11_path_once()
+{
+    _p11_path=$1
+    [ -z "$_p11_path" ] && return 0
+    case ":$_p11_seen:" in
+        *:"$_p11_path":*) return 0 ;;
+    esac
+    _p11_seen="${_p11_seen}${_p11_path}:"
+    printf '%s\n' "$_p11_path"
+}
+
+build_p11_libpaths()
+{
+    _p11_seen=
+    _old_ifs=$IFS
+    # PKCS11_LIBPATHS is space-separated; force word splitting on spaces here.
+    IFS=' '
+
+    for _p11_path in $PKCS11_LIBPATHS; do
+        p11_path_once "$_p11_path"
+    done
+
+    IFS=$_old_ifs
+
+    # Homebrew: HOMEBREW_PREFIX is set by 'eval "$(brew shellenv)"' — no subprocess needed.
+    if [ -n "${HOMEBREW_PREFIX:-}" ]; then
+        p11_path_once "$HOMEBREW_PREFIX/lib"
+        p11_path_once "$HOMEBREW_PREFIX/lib/pkcs11"
+    fi
+
+    p11_path_once /usr/lib
+    p11_path_once /usr/lib/pkcs11
+    if [ "$(uname -s)" = "Linux" ]; then
+        p11_path_once /usr/lib64
+        p11_path_once /usr/lib64/pkcs11
+        p11_path_once "/usr/lib/$(uname -m)-linux-gnu"
+    fi
+    p11_path_once /usr/local/lib
+    p11_path_once /usr/local/lib/pkcs11
+    p11_path_once "$HOME/.local/lib"
+}
+
+# find_p11_lib: search PKCS11_LIBPATHS for PKCS11_LIBNAME
+find_p11_lib()
+{
+    lib=$PKCS11_LIBNAME
+    _old_ifs=$IFS
+    IFS='
+'
+    for path in $(build_p11_libpaths); do
+        if [ -e "$path/$lib" ]; then
+            echo "$path/$lib"
+            IFS=$_old_ifs
+            return 0
+        fi
+    done
+    IFS=$_old_ifs
+    echo "NOT_FOUND"
+    return 1
+}
+
+# find_shim_lib: locate libpkcs11shim.dylib / libpkcs11shim.so
+# Try .dylib first (preferred on Darwin), then .so, in every search path.
+find_shim_lib()
+{
+    _old_ifs=$IFS
+    IFS='
+'
+    for path in $(build_p11_libpaths); do
+        if [ -e "$path/libpkcs11shim.dylib" ]; then
+            echo "$path/libpkcs11shim.dylib"
+            IFS=$_old_ifs
+            return 0
+        fi
+        if [ -e "$path/libpkcs11shim.so" ]; then
+            echo "$path/libpkcs11shim.so"
+            IFS=$_old_ifs
+            return 0
+        fi
+    done
+    IFS=$_old_ifs
+    echo "NOT_FOUND"
+    return 1
+}
+
+# find_cfg_file FILE PATH...
+# Generic helper: locate FILE in a list of directories.
+find_cfg_file()
+{
+    file=$1
+    shift
+    for path in "$@"; do
+        if [ -e "$path/$file" ]; then
+            echo "$path/$file"
+            return 0
+        fi
+    done
+    echo "NOT_FOUND"
+    return 1
+}
+
+# emit_rc_template: print a starter rc file for this vendor.
+# Each with_xxx wrapper overrides this with its own vendor-specific content.
+# This fallback is used when no wrapper-defined version exists.
+if ! type emit_rc_template > /dev/null 2>&1; then
+    emit_rc_template()
+    {
+        cat <<'EOF'
+# -*- sh -*-
+# .pkcs11rc - PKCS#11 token settings
+# Sourced automatically by with_xxx before executing any command.
+#
+# Use the case block below to set vendor-specific variables, or set them
+# directly if you only ever use one vendor in this directory.
+
+# ── Common settings ──────────────────────────────────────────────────────────
+# Token selection: use PKCS11SLOT *or* PKCS11TOKENLABEL (not both)
+#PKCS11SLOT=0
+#PKCS11TOKENLABEL=
+
+# Token PIN
+#PKCS11PASSWORD=changeit
+
+# Override library path (auto-detected by default)
+#PKCS11LIB=
+
+# ── Vendor-specific settings ─────────────────────────────────────────────────
+case ${_p11_vendor:-} in
+
+    aws)
+        # AWS CloudHSM: password format is "username:password"
+        #PKCS11PASSWORD=user:changeit
+        ;;
+
+    beid)
+        # Belgian eID: no PIN — entered directly via the card reader
+        ;;
+
+    kryoptic)
+        # Kryoptic TOML configuration file
+        #KRYOPTIC_CONF=$HOME/.config/kryoptic/token.conf
+        ;;
+
+    luna)
+        # SafeNet Luna: password may be "partition:password" depending on firmware
+        #PKCS11PASSWORD=changeit
+        ;;
+
+    nfast)
+        # Entrust nFast/nShield: OCS is slot 1 (slot 0 is the accelerator slot)
+        #PKCS11SLOT=1
+        #CKNFAST_LOADSHARING=1
+        #CKNFAST_FAKE_ACCELERATOR_LOGIN=1
+        # Debugging:
+        #CKNFAST_DEBUG=9
+        #CKNFAST_DEBUGDIR=/var/tmp
+        #CKNFAST_OVERRIDE_SECURITY_ASSURANCES=
+        ;;
+
+    nss)
+        # NSS (softokn3): slot 1 is the first user slot (slot 0 is internal)
+        # Create a database first: modutil -dbdir sql:. -create
+        #PKCS11SLOT=1
+        #PKCS11PASSWORD=ch@nge1t
+        #PKCS11NSSDIR=sql:.
+        #NSS_LIB_PARAMS=configDir=\'${PKCS11NSSDIR}\'
+        ;;
+
+    softhsm)
+        # SoftHSM2 configuration file
+        #SOFTHSM2_CONF=$HOME/.config/softhsm2/softhsm2.conf
+        ;;
+
+    utimaco)
+        # Utimaco configuration file (R3 preferred; R2 as fallback)
+        #CS_PKCS11_R3_CFG=/opt/utimaco/cs_pkcs11_R3.cfg
+        #CS_PKCS11_R2_CFG=/opt/utimaco/cs_pkcs11_R2.cfg
+        ;;
+
+esac
+# vim: set ft=sh :
+EOF
+    }
+fi
+
+########################################################################
+# print_help: usage summary printed by -h and on unknown options.
+print_help()
+{
+    _prog=$(basename "$0")
+    cat >&2 <<EOF
+Usage: $_prog [options] command [args...]
+       $_prog -c | -e | -h
+
+Options:
+  -n            No slot: unset PKCS11SLOT and PKCS11TOKENLABEL (interactive selection)
+  -s            SHIM mode: trace PKCS#11 calls, output to stderr
+  -S dest       SHIM mode: trace PKCS#11 calls, output to dest (file or /dev/stdout)
+  -c            Create a template .pkcs11rc in the current directory and exit
+  -e            Open .pkcs11rc in \$VISUAL/\$EDITOR (creates it first if absent)
+  -h            Show this help and exit
+
+Environment:
+  PKCS11LIB     Override library path (auto-detected otherwise)
+  PKCS11SLOT    Slot index to use (default: 0)
+  PKCS11TOKENLABEL  Select slot by token label instead of index
+  PKCS11PASSWORD    Token PIN (default: changeit)
+  PKCS11NSSDIR  NSS database directory (NSS only; default: sql:\$HOME/.pki/nssdb)
+  NOSLOT=1      Equivalent to -n
+  NORC=1        Skip sourcing any .pkcs11rc file
+  SHIM=dest     Equivalent to -S dest
+  HOMEBREW_PREFIX   Set by 'eval "\$(brew shellenv)"; used for library search
+
+.pkcs11rc:
+  Sourced automatically before executing the command.
+  Walk up from CWD to \$HOME; first match wins.
+  Use 'with_xxx -c' to create a template.
+EOF
+}
+
+########################################################################
+# Parse wrapper flags.
+# These are consumed here and do not reach the command being executed.
+while :; do
+    case "${1:-}" in
+        -n) NOSLOT=1          ; shift ;;
+        -s) SHIM=/dev/stderr  ; shift ;;
+        -S) shift
+            SHIM="${1:?'with_xxx -S requires a destination argument'}"
+            shift ;;
+        -h) print_help; exit 0 ;;
+        -c|-e) break ;;  # handled after the loop
+        -*) echo "***Error: unknown option: $1" >&2; print_help; exit 1 ;;
+        *)  break ;;
+    esac
+done
+
+# No arguments left after flag parsing: show help.
+if [ $# -eq 0 ]; then
+    print_help
+    exit 1
+fi
+
+########################################################################
+# Handle -c: create a template .pkcs11rc in the current directory.
+if [ "${1:-}" = "-c" ]; then
+    _rc_file=".pkcs11rc"
+    if [ -e "$_rc_file" ]; then
+        echo "***Error: $_rc_file already exists, not overwriting." >&2
+        exit 1
+    fi
+    emit_rc_template > "$_rc_file"
+    echo "Created $_rc_file" >&2
+    exit 0
+fi
+
+########################################################################
+# Handle -e: open .pkcs11rc in $VISUAL / $EDITOR (fallback: vi).
+if [ "${1:-}" = "-e" ]; then
+    _rc_file=""
+    _dir="$PWD"
+    while :; do
+        if [ -e "$_dir/.pkcs11rc" ]; then
+            _rc_file="$_dir/.pkcs11rc"
+            break
+        fi
+        [ "$_dir" = "$HOME" ] && break
+        [ "$_dir" = "/"    ] && break
+        _dir="${_dir%/*}"
+        [ -z "$_dir" ] && _dir="/"
+    done
+    if [ -z "$_rc_file" ]; then
+        _rc_file="$PWD/.pkcs11rc"
+        emit_rc_template > "$_rc_file"
+        echo "Created $_rc_file" >&2
+    fi
+    _editor="${VISUAL:-${EDITOR:-vi}}"
+    # eval allows VISUAL/EDITOR to contain flags (e.g. "code --wait" or "vi -R")
+    eval exec \"\$_editor\" \"\$_rc_file\"
+fi
+
+########################################################################
+# Source .pkcs11rc (or .pkcs11rc.<vendor> if _p11_vendor is set)
+# Walk up from CWD to $HOME; at each level try the vendor-specific file
+# first, then the generic one.  Stop at the first match found.
+# Never go above $HOME.
+if [ -z "${NORC:-}" ]; then
+    _dir="$PWD"
+    _found_rc=""
+    while :; do
+        if [ -n "${_p11_vendor:-}" ] && [ -e "$_dir/.pkcs11rc.$_p11_vendor" ]; then
+            _found_rc="$_dir/.pkcs11rc.$_p11_vendor"
+            break
+        fi
+        if [ -e "$_dir/.pkcs11rc" ]; then
+            _found_rc="$_dir/.pkcs11rc"
+            break
+        fi
+        # stop once we have checked $HOME
+        if [ "$_dir" = "$HOME" ]; then
+            break
+        fi
+        # stop if we are already at the filesystem root
+        if [ "$_dir" = "/" ]; then
+            break
+        fi
+        _dir="${_dir%/*}"
+        # edge case: _dir becomes empty when PWD is a top-level dir
+        [ -z "$_dir" ] && _dir="/"
+    done
+    if [ -n "$_found_rc" ]; then
+        # shellcheck source=/dev/null
+        . "$_found_rc"
+    fi
+    unset _dir _found_rc
+fi
+
+########################################################################
+# Vendor post-rc hook
+# A with_xxx wrapper may define p11_post_rc() to finalize its environment
+# *after* .pkcs11rc has been sourced — e.g. to derive a variable from another
+# one that the user may have overridden in .pkcs11rc.  No-op when undefined.
+if type p11_post_rc > /dev/null 2>&1; then
+    p11_post_rc
+fi
+
+########################################################################
+# Resolve the vendor library
+PKCS11LIB=${PKCS11LIB:-$(find_p11_lib)}
+
+if [ "$PKCS11LIB" = "NOT_FOUND" ]; then
+    echo "***Error: PKCS#11 Library not found, please set PKCS11LIB accordingly." >&2
+    exit 1
+fi
+
+# SHIM mode: interpose libpkcs11shim between the app and the token library
+if [ -n "${SHIM:-}" ]; then
+    echo "SHIM set, trying to hook libpkcs11shim, output goes to $SHIM" >&2
+    PKCS11SHIM="$PKCS11LIB"
+    PKCS11SHIM_OUTPUT="$SHIM"
+    PKCS11LIB=$(find_shim_lib)
+    if [ "$PKCS11LIB" = "NOT_FOUND" ]; then
+        echo "***Error: libpkcs11shim not found, can't use SHIM option" >&2
+        exit 1
+    fi
+fi
+
+# Slot handling
+# If NOSLOT is defined, clear both PKCS11SLOT and PKCS11TOKENLABEL.
+# Otherwise, if PKCS11TOKENLABEL is set, skip the default slot.
+if [ -n "${NOSLOT:-}" ]; then
+    unset PKCS11TOKENLABEL PKCS11SLOT
+elif [ -z "${PKCS11TOKENLABEL:-}" ]; then
+    PKCS11SLOT=${PKCS11SLOT:-0}
+fi
+
+########################################################################
+# Build the environment and exec the command
+
+_variables="PKCS11LIB PKCS11NSSDIR PKCS11SLOT PKCS11TOKENLABEL PKCS11PASSWORD PKCS11SHIM PKCS11SHIM_OUTPUT"
+
+for _v in $_variables $LIB_ENVVARS; do
+    eval "_val=\${$_v-}"
+    if [ -n "$_val" ]; then
+        export "$_v=$_val"
+    fi
+done
+
+"$@"
+exit $?

--- a/with_pkcs11_common
+++ b/with_pkcs11_common
@@ -369,38 +369,50 @@ fi
 
 ########################################################################
 # Source .pkcs11rc (or .pkcs11rc.<vendor> if _p11_vendor is set)
-# Walk up from CWD to $HOME; at each level try the vendor-specific file
-# first, then the generic one.  Stop at the first match found.
-# Never go above $HOME.
-if [ -z "${NORC:-}" ]; then
-    _dir="$PWD"
-    _found_rc=""
-    while :; do
-        if [ -n "${_p11_vendor:-}" ] && [ -e "$_dir/.pkcs11rc.$_p11_vendor" ]; then
-            _found_rc="$_dir/.pkcs11rc.$_p11_vendor"
-            break
-        fi
-        if [ -e "$_dir/.pkcs11rc" ]; then
-            _found_rc="$_dir/.pkcs11rc"
-            break
-        fi
-        # stop once we have checked $HOME
-        if [ "$_dir" = "$HOME" ]; then
-            break
-        fi
-        # stop if we are already at the filesystem root
-        if [ "$_dir" = "/" ]; then
-            break
-        fi
-        _dir="${_dir%/*}"
-        # edge case: _dir becomes empty when PWD is a top-level dir
-        [ -z "$_dir" ] && _dir="/"
-    done
-    if [ -n "$_found_rc" ]; then
-        # shellcheck source=/dev/null
-        . "$_found_rc"
-    fi
-    unset _dir _found_rc
+# Walk up from CWD to $HOME, trying the vendor-specific file first and then the
+# generic one at each level; the first match wins.
+#
+# The walk NEVER goes above $HOME: a .pkcs11rc is only ever sourced from $HOME
+# or one of its subdirectories.  This is deliberate as the file is sourced as a
+# shell script, so honoring one found above $HOME (for instance a world-
+# writable /tmp/.pkcs11rc seen when running from outside your home tree) would
+# let another user execute code in this process.  When CWD is outside $HOME no
+# .pkcs11rc is sourced; keep your configuration under $HOME, or use NORC=1 to
+# skip this step entirely.
+if [ -z "${NORC:-}" ] && [ -n "${HOME:-}" ] && [ "$HOME" != "/" ]; then
+    # A .pkcs11rc is honored only when CWD is $HOME or a directory beneath it,
+    # so the walk below can never escape $HOME.  Strip any trailing slash from
+    # $HOME so the containment test and the loop's stop condition agree.
+    _home=${HOME%/}
+    case "$PWD/" in
+        "$_home"/*)
+            _dir="$PWD"
+            _found_rc=""
+            while :; do
+                if [ -n "${_p11_vendor:-}" ] && [ -e "$_dir/.pkcs11rc.$_p11_vendor" ]; then
+                    _found_rc="$_dir/.pkcs11rc.$_p11_vendor"
+                    break
+                fi
+                if [ -e "$_dir/.pkcs11rc" ]; then
+                    _found_rc="$_dir/.pkcs11rc"
+                    break
+                fi
+                # Stop at $HOME; never walk above it.  $HOME is always reached
+                # because CWD was verified to be within it.
+                [ "$_dir" = "$_home" ] && break
+                [ "$_dir" = "/" ] && break
+                _dir="${_dir%/*}"
+                # edge case: _dir becomes empty when a parent is a top-level dir
+                [ -z "$_dir" ] && _dir="/"
+            done
+            if [ -n "$_found_rc" ]; then
+                # shellcheck source=/dev/null
+                . "$_found_rc"
+            fi
+            unset _dir _found_rc
+            ;;
+    esac
+    unset _home
 fi
 
 ########################################################################

--- a/with_pkcs11_common
+++ b/with_pkcs11_common
@@ -104,9 +104,11 @@ build_p11_libpaths()
     p11_path_once /usr/lib
     p11_path_once /usr/lib/pkcs11
     if [ "$(uname -s)" = "Linux" ]; then
+        _p11_triplet="$(uname -m)-linux-gnu"
         p11_path_once /usr/lib64
         p11_path_once /usr/lib64/pkcs11
-        p11_path_once "/usr/lib/$(uname -m)-linux-gnu"
+        p11_path_once "/usr/lib/$_p11_triplet"
+        p11_path_once "/usr/lib/$_p11_triplet/pkcs11"
     fi
     p11_path_once /usr/local/lib
     p11_path_once /usr/local/lib/pkcs11

--- a/with_pkcs11_common
+++ b/with_pkcs11_common
@@ -116,9 +116,17 @@ build_p11_libpaths()
 }
 
 # find_p11_lib: search PKCS11_LIBPATHS for PKCS11_LIBNAME
+# A with_xxx wrapper may define its own find_p11_lib() *before* sourcing this
+# file (e.g. with_utimaco, which probes several candidate library names via
+# PKCS11_LIBNAMES).  Only provide this default when no override is in place,
+# otherwise sourcing this file would clobber the wrapper's version.
+if ! type find_p11_lib > /dev/null 2>&1; then
 find_p11_lib()
 {
     lib=$PKCS11_LIBNAME
+    # An empty library name would turn the test below into [ -e "$path/" ],
+    # which matches any existing directory and returns a bogus path; guard it.
+    [ -z "$lib" ] && { echo "NOT_FOUND"; return 1; }
     _old_ifs=$IFS
     IFS='
 '
@@ -133,9 +141,13 @@ find_p11_lib()
     echo "NOT_FOUND"
     return 1
 }
+fi
 
 # find_shim_lib: locate libpkcs11shim.dylib / libpkcs11shim.so
 # Try .dylib first (preferred on Darwin), then .so, in every search path.
+# As with find_p11_lib, a wrapper may override this; only define the default
+# when the wrapper has not already provided one.
+if ! type find_shim_lib > /dev/null 2>&1; then
 find_shim_lib()
 {
     _old_ifs=$IFS
@@ -157,6 +169,7 @@ find_shim_lib()
     echo "NOT_FOUND"
     return 1
 }
+fi
 
 # find_cfg_file FILE PATH...
 # Generic helper: locate FILE in a list of directories.

--- a/with_softhsm
+++ b/with_softhsm
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (c) 2020 Mastercard
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,188 +13,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
-# Usage: with_xxxx p11command args... ==> execute the command using presets for the token
-#
-# each platform has its defaults.
-#
-# if not otherwise specified:
-# - default slot is set to 0 (define PKCS11SLOT or PKCS11TOKENLABEL to override)
-# - default password is generally set to 'changeit' (define PKCS11PASSWORD to override)
-#
-# You can set all the PKCS11XXXX variables in a configuration file (sourced by this script).
-# Two possibilites:
-# - $PWD/.pkcs11rc for a setup bound to a directory
-# - $HOME/.pkcs11rc for a user-wide setup
-#
-# alternate invocations:
-#
-# SPY=/dev/sdtout with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and print to stdout
-# SPY=p11.log with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and write logs to p11.log
-# NOSLOT with_xxxx p11command args... ==> unset slot and token variables, useful to force interactive mode
-# PKCS11TOKENLABEL="abc" with_xxxx p11command args... ==> you can set all PKCS11 variables you like,
-#                                                         including those that are vendor-specific
-#
-# Note that SPY mode does not support NSS.
+# wrapper script for SoftHSM2 tokens
+# see with_pkcs11_common for usage and alternate invocations
 
 PKCS11PASSWORD=${PKCS11PASSWORD:-changeit}
 
-#specific to vendor
+_p11_vendor=softhsm
+
+# vendor-specific settings
+# SoftHSM2 is built as a libtool module, so the library keeps the .so
+# extension on macOS as well (there is no .dylib variant).
 PKCS11_LIBNAME=libsofthsm2.so
-PKCS11_LIBPATHS=( /usr/local/lib/softhsm /usr/lib/softhsm /usr/lib /usr/lib64 /usr/local/opt/softhsm/lib/softhsm )
-LIB_ENVVARS=(SOFTHSM2_CONF)
-
-########################################################################
-
-# find_p11_lib: a trivial function to find a library.
-function find_p11_lib()
-{
-    lib=${PKCS11_LIBNAME}
-    paths=${PKCS11_LIBPATHS[@]}
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
+PKCS11_LIBPATHS="/usr/local/lib/softhsm /usr/lib/softhsm /usr/local/opt/softhsm/lib/softhsm"
+if [ -n "${HOMEBREW_PREFIX:-}" ]; then
+	PKCS11_LIBPATHS="$PKCS11_LIBPATHS $HOMEBREW_PREFIX/lib/softhsm"
+elif command -v brew > /dev/null 2>&1; then
+	_brew_prefix=$(brew --prefix 2>/dev/null)
+	if [ -n "$_brew_prefix" ]; then
+		PKCS11_LIBPATHS="$PKCS11_LIBPATHS $_brew_prefix/lib/softhsm"
 	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find a configuration file, provided a file name and paths
-function find_cfg_file()
-{
-    file=$1			# file name in $1
-    paths=${@:2}		# paths is an array ($2, $3, ...)
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_shim_lib: find libpkcs11shim.so
-function find_shim_lib()
-{
-    lib=libpkcs11shim.so
-    case "$(uname -s)" in
-	*)
-	    paths=( /usr/local/lib /usr/lib )
-	    ;;
-    esac
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_spy_lib: find pkcs11-spy.so from OpenSC
-function find_spy_lib()
-{
-    lib=pkcs11-spy.so
-    paths=( /usr/lib/$(uname -m)-linux-gnu/pkcs11 /usr/lib64 /usr/local/lib /usr/local/opt/opensc/lib )
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-
-# source .pkcs11rc from local directory, and if not, from $HOME directory
-if [ -z "$NORC" ]; then
-    if [ -e ./.pkcs11rc ]; then
-	source ./.pkcs11rc
-    elif [ -e $HOME/.pkcs11rc ]; then
-	source $HOME/.pkcs11rc
-    fi
+	unset _brew_prefix
 fi
+LIB_ENVVARS="SOFTHSM2_CONF"
 
-################################################################################
-
-# library
-PKCS11LIB=${PKCS11LIB:-$(find_p11_lib)}
-
-if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-    echo "***Error: PKCS#11 Library not found, please set PKCS11LIB accordingly."
-    exit 1
-fi
-
-# if SHIM is set, we want to use the libpkcs11shim
-#
-if [ -n "$SHIM" ]; then
-    echo "SHIM set, trying to hook libpkcs11shim.so, output goes to $SHIM"
-    PKCS11SHIM=$PKCS11LIB
-    PKCS11SHIM_OUTPUT=$SHIM
-    PKCS11LIB=$(find_shim_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: libpkcs11shim.so Library not found, can't use SHIM option"
-	exit 1
-    fi
-elif [ -n "$SPY" ]; then
-    echo "SPY set, trying to hook pkcs11-spy.so, output goes to $SPY"
-    PKCS11SPY=$PKCS11LIB
-    PKCS11SPY_OUTPUT=$SPY
-    PKCS11LIB=$(find_spy_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: pkcs11-spy.so Library not found, can't use SPY option"
-	exit 1
-    fi
-fi
-    
-    
-#if NOSLOT is defined, or if PKCS11TOKENLABEL is defined we skip PKCS11SLOT
-#(useful for p11slotinfo invocation)
-if [ -z "$NOSLOT" -a -z "$PKCS11TOKENLABEL" ]; then
-    PKCS11SLOT=${PKCS11SLOT:-0}
-fi
-
-# also, if NOSLOT is defined, we unset PKCS11TOKENLABEL and PKCS11SLOT
-if [ -n "$NOSLOT" ]; then
-    unset PKCS11TOKENLABEL PKCS11SLOT
-fi
-
-# Note: there is no default value for PKCS11TOKENLABEL
-
-################################################################################
-variables=(PKCS11LIB PKCS11NSSDIR PKCS11SLOT PKCS11TOKENLABEL PKCS11PASSWORD \
-		     PKCS11SHIM PKCS11SHIM_OUTPUT PKCS11SPY PKCS11SPY_OUTPUT)
-
-environment=
-for v in ${variables[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-for v in ${LIB_ENVVARS[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-quoted=
-for item in "$@"; do
-    quoted+=($(printf "%q" "$item"))
-done
-
-eval ${environment[@]} ${quoted[@]}
-exit $?
+# load common logic
+. "$(dirname "$0")/with_pkcs11_common" "$@"

--- a/with_utimaco
+++ b/with_utimaco
@@ -51,13 +51,23 @@ _find_utimaco_cfg()
     return 1
 }
 
-CS_PKCS11_R3_CFG=${CS_PKCS11_R3_CFG:-$(_find_utimaco_cfg)}
-CS_PKCS11_R2_CFG=${CS_PKCS11_R2_CFG:-$(_find_utimaco_cfg)}
+# Resolve and validate the config file *after* .pkcs11rc has been sourced, so a
+# user can point CS_PKCS11_R3_CFG/CS_PKCS11_R2_CFG at it from .pkcs11rc.
+# with_pkcs11_common calls this hook once the rc file has been loaded.
+p11_post_rc()
+{
+    CS_PKCS11_R3_CFG=${CS_PKCS11_R3_CFG:-$(_find_utimaco_cfg)}
+    CS_PKCS11_R2_CFG=${CS_PKCS11_R2_CFG:-$(_find_utimaco_cfg)}
 
-if [ "$CS_PKCS11_R2_CFG" = "NOT_FOUND" ] && [ "$CS_PKCS11_R3_CFG" = "NOT_FOUND" ]; then
-    echo "***Error: Utimaco configuration file not found, please set CS_PKCS11_R3_CFG/CS_PKCS11_R2_CFG accordingly." >&2
-    exit 1
-fi
+    if [ "$CS_PKCS11_R2_CFG" = "NOT_FOUND" ] && [ "$CS_PKCS11_R3_CFG" = "NOT_FOUND" ]; then
+        echo "***Error: Utimaco configuration file not found, please set CS_PKCS11_R3_CFG/CS_PKCS11_R2_CFG accordingly." >&2
+        exit 1
+    fi
+
+    # Never export the NOT_FOUND sentinel to the library.
+    [ "$CS_PKCS11_R3_CFG" = "NOT_FOUND" ] && unset CS_PKCS11_R3_CFG
+    [ "$CS_PKCS11_R2_CFG" = "NOT_FOUND" ] && unset CS_PKCS11_R2_CFG
+}
 
 # Utimaco has multiple possible library names; override find_p11_lib
 find_p11_lib()

--- a/with_utimaco
+++ b/with_utimaco
@@ -69,22 +69,29 @@ p11_post_rc()
     [ "$CS_PKCS11_R2_CFG" = "NOT_FOUND" ] && unset CS_PKCS11_R2_CFG
 }
 
-# Utimaco has multiple possible library names; override find_p11_lib
+# Utimaco has multiple possible library names; override find_p11_lib.
+# Names are space-separated (PKCS11_LIBNAMES) while build_p11_libpaths emits
+# one path per line (paths may contain spaces).  Iterate names first using the
+# default IFS so they split on spaces, and only switch IFS to newline for the
+# inner path loop.  Doing it the other way round makes the inner name loop run
+# with IFS=newline, so PKCS11_LIBNAMES is never split and nothing is found.
+# Name-major order also means the preferred R3 library wins over R2 even when
+# R2 sits in an earlier search directory.
 find_p11_lib()
 {
     _old_ifs=$IFS
-    IFS='
+    for lib in $PKCS11_LIBNAMES; do
+        IFS='
 '
-    for path in $(build_p11_libpaths); do
-        for lib in $PKCS11_LIBNAMES; do
+        for path in $(build_p11_libpaths); do
             if [ -e "$path/$lib" ]; then
                 echo "$path/$lib"
                 IFS=$_old_ifs
                 return 0
             fi
         done
+        IFS=$_old_ifs
     done
-    IFS=$_old_ifs
     echo "NOT_FOUND"
     return 1
 }

--- a/with_utimaco
+++ b/with_utimaco
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (c) 2020 Mastercard
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,201 +13,71 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# wrapper script for Utimaco tokens
+# see with_pkcs11_common for usage and alternate invocations
 #
-# Usage: with_xxxx p11command args... ==> execute the command using presets for the token
-#
-# each platform has its defaults.
-#
-# if not otherwise specified:
-# - default slot is set to 0 (define PKCS11SLOT or PKCS11TOKENLABEL to override)
-# - default password is generally set to 'changeit' (define PKCS11PASSWORD to override)
-#
-# You can set all the PKCS11XXXX variables in a configuration file (sourced by this script).
-# Two possibilites:
-# - $PWD/.pkcs11rc for a setup bound to a directory
-# - $HOME/.pkcs11rc for a user-wide setup
-#
-# alternate invocations:
-#
-# SPY=/dev/sdtout with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and print to stdout
-# SPY=p11.log with_xxxx p11command args... ==> to interface with pkcs11-spy.so (from OpenSC) and write logs to p11.log
-# NOSLOT with_xxxx p11command args... ==> unset slot and token variables, useful to force interactive mode
-# PKCS11TOKENLABEL="abc" with_xxxx p11command args... ==> you can set all PKCS11 variables you like,
-#                                                         including those that are vendor-specific
-#
-# Note that SPY mode does not support NSS.
+# Utimaco-specific notes:
+#   - supports both R2 and R3 client libraries (auto-detected)
+#   - CS_PKCS11_R2_CFG / CS_PKCS11_R3_CFG point to the Utimaco config file
 
 PKCS11PASSWORD=${PKCS11PASSWORD:-changeit}
 
-# Specific to vendor
-# Utimaco: since there is no standard install, we are making a few guesses
-PKCS11_LIBPATHS=( /usr/lib/pkcs11 /usr/lib /usr/local/lib/pkcs11 /usr/local/lib /opt/utimaco/lib $HOME/utimaco/pkcs11/lib $HOME/utimaco/lib )
-# Utimaco: we try to detect setups for either R3 or R2 clients
-PKCS11_LIBNAMES=( libcs_pkcs11_R3.so libcs_pkcs11_R2.so )
-PKCS11_CFGNAMES=( cs_pkcs11_R3.cfg cs_pkcs11_R2.cfg )
-PKCS11_CFGPATHS=( /opt/utimaco /usr/local/etc /etc $HOME/utimaco/pkcs11 $HOME/utimaco )
+_p11_vendor=utimaco
 
-LIB_ENVVARS=( CS_PKCS11_R2_CFG CS_PKCS11_R3_CFG )
+# vendor-specific settings
+# Utimaco: since there is no standard install, we try a few common locations
+PKCS11_LIBPATHS="/opt/utimaco/lib $HOME/utimaco/pkcs11/lib $HOME/utimaco/lib"
+case $(uname -s) in
+    Darwin) PKCS11_LIBNAMES="libcs_pkcs11_R3.dylib libcs_pkcs11_R2.dylib" ;;
+    *)      PKCS11_LIBNAMES="libcs_pkcs11_R3.so libcs_pkcs11_R2.so"       ;;
+esac
+PKCS11_CFGNAMES="cs_pkcs11_R3.cfg cs_pkcs11_R2.cfg"
+PKCS11_CFGPATHS="/opt/utimaco /usr/local/etc /etc $HOME/utimaco/pkcs11 $HOME/utimaco"
 
+LIB_ENVVARS="CS_PKCS11_R2_CFG CS_PKCS11_R3_CFG"
 
-# setup of CS_PKCS11_R2_CFG / CS_PKCS11_R3_CFG
-# we expect to find it in /opt/utimaco or in /usr/local/etc
-function find_utimaco_cfg_file()
+# Utimaco requires a config file — locate it if not already set
+_find_utimaco_cfg()
 {
-    for path in ${PKCS11_CFGPATHS[@]}; do
-	for file in ${PKCS11_CFGNAMES[@]}; do
-	    if [ -e $path/$file ]; then
-		echo $path/$file
-		return 0
-	    fi
-	done
+    for path in $PKCS11_CFGPATHS; do
+        for file in $PKCS11_CFGNAMES; do
+            if [ -e "$path/$file" ]; then
+                echo "$path/$file"
+                return 0
+            fi
+        done
     done
-
     echo "NOT_FOUND"
     return 1
 }
 
-CS_PKCS11_R3_CFG=${CS_PKCS11_R3_CFG:-$(find_utimaco_cfg_file)}
-CS_PKCS11_R2_CFG=${CS_PKCS11_R2_CFG:-$(find_utimaco_cfg_file)}
+CS_PKCS11_R3_CFG=${CS_PKCS11_R3_CFG:-$(_find_utimaco_cfg)}
+CS_PKCS11_R2_CFG=${CS_PKCS11_R2_CFG:-$(_find_utimaco_cfg)}
 
-if [ "$CS_PKCS11_R2_CFG" == "NOT_FOUND" -a "$CS_PKCS11_R3_CFG" == "NOT_FOUND" ]; then
-    echo "***Error: Utimaco configuration file not found, please set CS_PKCS11_R3_CFG/CS_PKCS11_R2_CFG accordingly."
+if [ "$CS_PKCS11_R2_CFG" = "NOT_FOUND" ] && [ "$CS_PKCS11_R3_CFG" = "NOT_FOUND" ]; then
+    echo "***Error: Utimaco configuration file not found, please set CS_PKCS11_R3_CFG/CS_PKCS11_R2_CFG accordingly." >&2
     exit 1
 fi
 
-########################################################################
-
-# find_p11_lib: a trivial function to find a library.
-function find_p11_lib()
+# Utimaco has multiple possible library names; override find_p11_lib
+find_p11_lib()
 {
-    for path in ${PKCS11_LIBPATHS[@]}; do
-	for lib in ${PKCS11_LIBNAMES[@]}; do
-	    if [ -e $path/$lib ]; then
-		echo $path/$lib
-		return 0
-	    fi
-	done
+    _old_ifs=$IFS
+    IFS='
+'
+    for path in $(build_p11_libpaths); do
+        for lib in $PKCS11_LIBNAMES; do
+            if [ -e "$path/$lib" ]; then
+                echo "$path/$lib"
+                IFS=$_old_ifs
+                return 0
+            fi
+        done
     done
-
+    IFS=$_old_ifs
     echo "NOT_FOUND"
     return 1
 }
 
-# find_shim_lib: find libpkcs11shim.so
-function find_shim_lib()
-{
-    lib=libpkcs11shim.so
-    case "$(uname -s)" in
-	*)
-	    paths=( /usr/local/lib /usr/lib )
-	    ;;
-    esac
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-# find_spy_lib: find pkcs11-spy.so from OpenSC
-function find_spy_lib()
-{
-    lib=pkcs11-spy.so
-    paths=( /usr/lib/$(uname -m)-linux-gnu/pkcs11 /usr/lib64 /usr/local/lib /usr/local/opt/opensc/lib )
-
-    for path in ${paths[@]}; do
-	if [ -e $path/$lib ]; then
-	    echo $path/$lib
-	    return 0
-	fi
-    done
-
-    echo "NOT_FOUND"
-    return 1
-}
-
-
-# source .pkcs11rc from local directory, and if not, from $HOME directory
-if [ -z "$NORC" ]; then
-    if [ -e ./.pkcs11rc ]; then
-	source ./.pkcs11rc
-    elif [ -e $HOME/.pkcs11rc ]; then
-	source $HOME/.pkcs11rc
-    fi
-fi
-
-################################################################################
-
-# library
-PKCS11LIB=${PKCS11LIB:-$(find_p11_lib)}
-
-if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-    echo "***Error: PKCS#11 Library not found, please set PKCS11LIB accordingly."
-    exit 1
-fi
-
-# if SHIM is set, we want to use the libpkcs11shim
-#
-if [ -n "$SHIM" ]; then
-    echo "SHIM set, trying to hook libpkcs11shim.so, output goes to $SHIM"
-    PKCS11SHIM=$PKCS11LIB
-    PKCS11SHIM_OUTPUT=$SHIM
-    PKCS11LIB=$(find_shim_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: libpkcs11shim.so Library not found, can't use SHIM option"
-	exit 1
-    fi
-elif [ -n "$SPY" ]; then
-    echo "SPY set, trying to hook pkcs11-spy.so, output goes to $SPY"
-    PKCS11SPY=$PKCS11LIB
-    PKCS11SPY_OUTPUT=$SPY
-    PKCS11LIB=$(find_spy_lib)
-    if [ "$PKCS11LIB" == "NOT_FOUND" ]; then
-	echo "***Error: pkcs11-spy.so Library not found, can't use SPY option"
-	exit 1
-    fi
-fi
-    
-    
-#if NOSLOT is defined, or if PKCS11TOKENLABEL is defined we skip PKCS11SLOT
-#(useful for p11slotinfo invocation)
-if [ -z "$NOSLOT" -a -z "$PKCS11TOKENLABEL" ]; then
-    PKCS11SLOT=${PKCS11SLOT:-0}
-fi
-
-# also, if NOSLOT is defined, we unset PKCS11TOKENLABEL and PKCS11SLOT
-if [ -n "$NOSLOT" ]; then
-    unset PKCS11TOKENLABEL PKCS11SLOT
-fi
-
-# Note: there is no default value for PKCS11TOKENLABEL
-
-################################################################################
-variables=(PKCS11LIB PKCS11NSSDIR PKCS11SLOT PKCS11TOKENLABEL PKCS11PASSWORD \
-		     PKCS11SHIM PKCS11SHIM_OUTPUT PKCS11SPY PKCS11SPY_OUTPUT)
-
-environment=
-for v in ${variables[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-for v in ${LIB_ENVVARS[@]}; do
-    if [ -n "${!v}" ]; then
-	environment+=("$v=${!v}")
-    fi
-done
-
-quoted=
-for item in "$@"; do
-    quoted+=($(printf "%q" "$item"))
-done
-
-eval ${environment[@]} ${quoted[@]}
-exit $?
+# load common logic
+. "$(dirname "$0")/with_pkcs11_common" "$@"


### PR DESCRIPTION
- Changed shebang from bash to sh for consistency across scripts.
- Introduced a new common script `with_pkcs11_common` to encapsulate shared logic for handling PKCS#11 libraries and configurations.
- Updated individual wrapper scripts (`with_nss`, `with_softhsm`, `with_utimaco`) to source the common script and remove redundant code.
- Adjusted library path handling and configuration file detection for Utimaco and SoftHSM2.
- Enhanced error handling for missing configuration files and libraries.
- Updated default password complexity for NSS tokens.
- Improved comments and documentation for clarity on usage and expected variables.
- Added support for Kryoptic