### PR TITLE
fix: six bug fixes in libp11 and CLI tools (exit codes, search-template parsing, parser state)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+### Fixed
+- `p11wrap`: fixed usage-error handling so invalid/missing CLI arguments now return a non-zero status (`rc_error_usage`) instead of success.
+- `p11req` and `p11mkcert`: fixed error propagation so CSR/certificate generation failures now return a non-zero status (`rc_error_other_error`) instead of success.
+- `p11cp` and `p11mv`: fixed return-code propagation so copy/move failures are no longer silently reported as success by the command entry points.
+- `p11cp` and `p11mv`: fixed destination-existence checks for prefixed destinations (`<class>/<label>`) by checking the parsed destination label rather than the raw destination string.
+- fixed extended object-filter parsing (`class/attr/value+...`) in search templates (`pkcs11_template`) by correcting `strsep` delimiter usage and attribute value tokenization.
+- fixed wrapped-key parser state leakage across parses by resetting `parsing_envelope` before each parse entry point (`pkcs11_prepare_wrappingctx`, `pkcs11_new_wrapped_key_from_file`).
+- `pkcs11_change_object_attributes`: fixed OID/ID retrieval to read `CKA_ID` (not `CKA_LABEL`) when inspecting matched objects.
+
 # [3.0.0] - 2026-06-30
 ### Added
 - support for Post-Quantum Cryptography (PQC): the three NIST/PKCS#11 v3.2 algorithms ML-KEM (FIPS 203), ML-DSA (FIPS 204) and SLH-DSA (FIPS 205) are now supported. `p11keygen` can generate `mlkem`, `mldsa` and `slhdsa` key pairs; the parameter set is selected through `-b` for ML-KEM (`512`, `768`, `1024`) and ML-DSA (`44`, `65`, `87`), and through `-q` for SLH-DSA (`{sha2,shake}-{128,192,256}{s,f}`, e.g. `sha2-128s` or `shake-256f`). `p11ls`, `p11od`, `p11cat` and `p11more` display and export the new key types, and `p11req`/`p11mkcert` can produce CSRs and self-signed certificates for ML-DSA and SLH-DSA keys. PQC support is enabled by default and can be turned off at compile time with `--disable-pqc`; key generation and object inspection only require any OpenSSL 3.x, while public key export, CSR and certificate creation additionally require `libcrypto >= 3.5.0` (when older, those operations are disabled while key generation and inspection remain available). `bash`/`zsh` completion has been extended to the new key types and parameter sets
@@ -173,6 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial public release
 
 [3.0.0]: https://github.com/Mastercard/pkcs11-tools/tree/v3.0.0
+[Unreleased]: https://github.com/Mastercard/pkcs11-tools/compare/v3.0.0...HEAD
 [2.6.0]: https://github.com/Mastercard/pkcs11-tools/tree/v2.6.0
 [2.5.1]: https://github.com/Mastercard/pkcs11-tools/tree/v2.5.1
 [2.5.0]: https://github.com/Mastercard/pkcs11-tools/tree/v2.5.0

--- a/lib/pkcs11_chattr.c
+++ b/lib/pkcs11_chattr.c
@@ -66,7 +66,7 @@ func_rc pkcs11_change_object_attributes(pkcs11Context *p11Context, char *label, 
 
 			CK_ATTRIBUTE_PTR oclass = pkcs11_get_attr_in_attrlist(attrs, CKA_CLASS);
 			CK_ATTRIBUTE_PTR olabel = pkcs11_get_attr_in_attrlist(attrs, CKA_LABEL);
-			CK_ATTRIBUTE_PTR oid    = pkcs11_get_attr_in_attrlist(attrs, CKA_LABEL);
+			CK_ATTRIBUTE_PTR oid    = pkcs11_get_attr_in_attrlist(attrs, CKA_ID);
 
 
 			if(oclass) {

--- a/lib/pkcs11_cp.c
+++ b/lib/pkcs11_cp.c
@@ -104,7 +104,7 @@ int pkcs11_cp_objects(pkcs11Context *p11Context, char *src, char *dest, int inte
 	break;
 
     case prvk:
-	if(pkcs11_privatekey_exists( p11Context, dest)) {
+	if(pkcs11_privatekey_exists( p11Context, destlabel)) {
 #ifdef HAVE_DUPLICATES_ENABLED
 		if(p11Context->can_duplicate) {
 			fprintf(stdout,"Warning: a private key already exists for destination label '%s', duplicating.\n", dest);
@@ -121,7 +121,7 @@ int pkcs11_cp_objects(pkcs11Context *p11Context, char *src, char *dest, int inte
 	break;
 
     case pubk:
-	if(pkcs11_publickey_exists( p11Context, dest)) {
+	if(pkcs11_publickey_exists( p11Context, destlabel)) {
 #ifdef HAVE_DUPLICATES_ENABLED
 		if(p11Context->can_duplicate) {
 			fprintf(stdout,"Warning: a public key already exists for destination label '%s', duplicating.\n", dest);
@@ -138,7 +138,7 @@ int pkcs11_cp_objects(pkcs11Context *p11Context, char *src, char *dest, int inte
 	break;
 
     case seck:
-	if(pkcs11_secretkey_exists( p11Context, dest)) {
+	if(pkcs11_secretkey_exists( p11Context, destlabel)) {
 #ifdef HAVE_DUPLICATES_ENABLED
 		if(p11Context->can_duplicate) {
 			fprintf(stdout,"Warning: a secret key already exists for destination label '%s', duplicating.\n", dest);
@@ -155,7 +155,7 @@ int pkcs11_cp_objects(pkcs11Context *p11Context, char *src, char *dest, int inte
 	break;
 
     case cert:
-	if(pkcs11_certificate_exists( p11Context, dest)) {
+	if(pkcs11_certificate_exists( p11Context, destlabel)) {
 #ifdef HAVE_DUPLICATES_ENABLED
 		if(p11Context->can_duplicate) {
 			fprintf(stdout,"Warning: a certificate already exists for destination label '%s', duplicating.\n", dest);

--- a/lib/pkcs11_mv.c
+++ b/lib/pkcs11_mv.c
@@ -109,7 +109,7 @@ int pkcs11_mv_objects(pkcs11Context *p11Context, char *src, char *dest, int inte
 	break;
 
     case prvk:
-	if(pkcs11_privatekey_exists( p11Context, dest)) {
+	if(pkcs11_privatekey_exists( p11Context, destlabel)) {
 #ifdef HAVE_DUPLICATES_ENABLED
 		if(p11Context->can_duplicate) {	
 	    	fprintf(stdout,"Warning: a private key already exists for destination label '%s', duplicating.\n", dest);
@@ -126,7 +126,7 @@ int pkcs11_mv_objects(pkcs11Context *p11Context, char *src, char *dest, int inte
 	break;
 
     case pubk:
-	if(pkcs11_publickey_exists( p11Context, dest)) {
+	if(pkcs11_publickey_exists( p11Context, destlabel)) {
 #ifdef HAVE_DUPLICATES_ENABLED
 		if(p11Context->can_duplicate) {	
 	    	fprintf(stdout,"Warning: a public key already exists for destination label '%s', duplicating.\n", dest);
@@ -143,7 +143,7 @@ int pkcs11_mv_objects(pkcs11Context *p11Context, char *src, char *dest, int inte
 	break;
 
     case seck:
-	if(pkcs11_secretkey_exists( p11Context, dest)) {
+	if(pkcs11_secretkey_exists( p11Context, destlabel)) {
 #ifdef HAVE_DUPLICATES_ENABLED
 		if(p11Context->can_duplicate) {	
 	    	fprintf(stdout,"Warning: a secret key already exists for destination label '%s', duplicating.\n", dest);
@@ -160,7 +160,7 @@ int pkcs11_mv_objects(pkcs11Context *p11Context, char *src, char *dest, int inte
 	break;
 
     case cert:
-	if(pkcs11_certificate_exists( p11Context, dest)) {
+	if(pkcs11_certificate_exists( p11Context, destlabel)) {
 #ifdef HAVE_DUPLICATES_ENABLED
 		if(p11Context->can_duplicate) {	
 	    	fprintf(stdout,"Warning: a certificate already exists for destination label '%s', duplicating.\n", dest);

--- a/lib/pkcs11_template.c
+++ b/lib/pkcs11_template.c
@@ -273,8 +273,8 @@ bool parse_attributes(char* attributes, pkcs11IdTemplate* template_buffer) {
 		return false;
 	}
 
-	const char forward_slash_delim = '/';
-	const char plus_delim = '+';
+	const char *forward_slash_delim = "/";
+	const char *plus_delim = "+";
 
 	char* attr_value_regex_str = "^(\\{([[:xdigit:].:[:space:]]+)\\}|([^/{}]+))$";
 	regex_t attr_value_regex;
@@ -286,12 +286,12 @@ bool parse_attributes(char* attributes, pkcs11IdTemplate* template_buffer) {
 	}
 	
 	char* label_ptr = NULL;
-	char* attr_type, *attr_value;
+	char* attr_type, *attr_value = NULL;
 	size_t label_len = 0;
 	CK_ATTRIBUTE_TYPE cka_resourceid;
-	char* attr = strsep(&attributes, &plus_delim);
+	char* attr = strsep(&attributes, plus_delim);
 	while(attr != NULL) {
-		attr_type = strsep(&attr, &forward_slash_delim);
+		attr_type = strsep(&attr, forward_slash_delim);
 		cka_resourceid = parse_attribute_type(attr_type);
 
 		if(cka_resourceid == 0xFFFFFFFF) {
@@ -302,7 +302,7 @@ bool parse_attributes(char* attributes, pkcs11IdTemplate* template_buffer) {
 		}
 		
 		if(!attr_value){
-			attr_value = strsep(&attr, &plus_delim);
+			attr_value = strsep(&attr, plus_delim);
 		}
 
 		label_ptr = parse_attribute_value(attr_value, &attr_value_regex, &label_len);
@@ -323,7 +323,7 @@ bool parse_attributes(char* attributes, pkcs11IdTemplate* template_buffer) {
 		else {
 			fprintf(stderr, "parse_attributes: failed to parse attribute value. - [%s]\n", attr);
 		}
-		attr = strsep(&attributes, &plus_delim);
+		attr = strsep(&attributes, plus_delim);
 		attr_type = NULL;
 		attr_value = NULL;
 	}
@@ -371,11 +371,11 @@ pkcs11IdTemplate * pkcs11_make_idtemplate_with_extra_attributes(char* url)
 		goto err;
     }
 
-	const char forward_slash_delim = '/';
+	const char *forward_slash_delim = "/";
 	char* savepoint = strdup(url);
 	char* cursor = savepoint;
 	CK_OBJECT_CLASS objectclass;
-	char* object_type = strsep(&cursor, &forward_slash_delim);
+	char* object_type = strsep(&cursor, forward_slash_delim);
 	if(object_type == NULL){
 		error_msg = "no class/data found.\n";
 	    goto err;

--- a/lib/pkcs11_unwrap.c
+++ b/lib/pkcs11_unwrap.c
@@ -32,6 +32,15 @@
 #include "wrappedkey_lexer.h"
 #include "wrappedkey_parser.h"
 
+/*
+ * parsing_envelope is a parser global (defined in wrappedkey_parser.y). It is
+ * normally balanced by the envelope() grammar rule, but a parse error inside an
+ * envelope() clause aborts via YYERROR before the closing action runs, leaving
+ * it non-zero. Each parse entry point resets it so state never leaks from a
+ * failed parse into the next one.
+ */
+extern int parsing_envelope;
+
 
 /*--------------------------------------------------------------------------------*/
 /* PROTOTYPES */
@@ -130,6 +139,8 @@ wrappedKeyCtx *pkcs11_new_wrapped_key_from_file(pkcs11Context *p11Context, char 
     }
 
     yyrestart(fp);
+
+    parsing_envelope = 0;	/* reset leftover parser state before a fresh parse */
 
     do {
 	parserc = yyparse(wctx);

--- a/lib/pkcs11_wrap.c
+++ b/lib/pkcs11_wrap.c
@@ -31,6 +31,10 @@
 #include "wrappedkey_lexer.h"
 #include "wrappedkey_parser.h"
 
+/* parser global (defined in wrappedkey_parser.y); reset before each parse so a
+ * failed envelope() parse cannot leak state into a subsequent parse. */
+extern int parsing_envelope;
+
 typedef enum {
     meth_label,
     meth_keyhandle
@@ -1037,6 +1041,8 @@ func_rc pkcs11_prepare_wrappingctx(wrappedKeyCtx *wctx, char *wrapjob) {
 	/* http://stackoverflow.com/questions/1907847/how-to-use-yy-scan-string-in-lex     */
 	/* copy string into new buffer and Switch buffers*/
 	YY_BUFFER_STATE yybufstate = yy_scan_string(wrapjob);
+
+	parsing_envelope = 0;	/* reset leftover parser state before a fresh parse */
 
 	/* parse string */
 	parserc = yyparse(wctx);

--- a/src/p11cp.c
+++ b/src/p11cp.c
@@ -214,8 +214,8 @@ int main( int argc, char ** argv )
 #ifdef HAVE_DUPLICATES_ENABLED
 	p11Context->can_duplicate = can_duplicate;
 #endif
-	pkcs11_cp_objects(p11Context, argv[optind], argv[optind+1], ask_confirm, verbose);
-	
+	retcode = pkcs11_cp_objects(p11Context, argv[optind], argv[optind+1], ask_confirm, verbose);
+
 	pkcs11_close_session( p11Context );
     }
     pkcs11_finalize( p11Context );

--- a/src/p11mkcert.c
+++ b/src/p11mkcert.c
@@ -445,6 +445,7 @@ int main( int argc, char ** argv )
 		pkcs11_free_X509_CERT(x509); /* free cert structure */
 	    } else {
 		fprintf(stderr, "Error: Unable to generate certificate\n");
+		retcode = rc_error_other_error;
 	    }
 	    pkcs11_delete_attrlist(attrlist);
 	} else {

--- a/src/p11mv.c
+++ b/src/p11mv.c
@@ -213,8 +213,8 @@ int main( int argc, char ** argv )
 #ifdef HAVE_DUPLICATES_ENABLED
 	p11Context->can_duplicate = can_duplicate;
 #endif
-	pkcs11_mv_objects(p11Context, argv[optind], argv[optind+1], ask_confirm, verbose);
-	
+	retcode = pkcs11_mv_objects(p11Context, argv[optind], argv[optind+1], ask_confirm, verbose);
+
 	pkcs11_close_session( p11Context );
     }
     pkcs11_finalize( p11Context );

--- a/src/p11req.c
+++ b/src/p11req.c
@@ -406,6 +406,7 @@ int main( int argc, char ** argv )
 		pkcs11_free_X509_REQ(req);
 	    } else {
 		fprintf(stderr, "Error: Unable to generate certificate request\n");
+		retcode = rc_error_other_error;
 	    }
 	    pkcs11_delete_attrlist(attrlist);
 	} else {

--- a/src/p11wrap.c
+++ b/src/p11wrap.c
@@ -300,7 +300,7 @@ int main(int argc, char **argv) {
 
     if (errflag) {
 	fprintf(stderr, "Try `%s -h' for more information.\n", argv[0]);
-	p11wraprc = rc_error_usage;
+	retcode = rc_error_usage;
 	goto epilog;
     }
 
@@ -308,7 +308,7 @@ int main(int argc, char **argv) {
 	option == option_unknown || (option == option_separate && wrappingjob[0].wrappingkeylabel == NULL)) {
 	fprintf(stderr, "At least one required option or argument is wrong or missing.\n"
 			"Try `%s -h' for more information.\n", argv[0]);
-	p11wraprc = rc_error_usage;
+	retcode = rc_error_usage;
 	goto epilog;
     }
 


### PR DESCRIPTION
## Summary

Six independent bug fixes to `libp11` and the command-line tools, targeting `master`.

These defects were **discovered while developing a dedicated test framework** (unit tests over the programmable mock + integration tests against SoftHSM2/NSS). They are proposed here **ahead of that larger test-suite PR**, so the fixes can be reviewed and merged on their own, decoupled from the (much larger) testing/CI/build-image changes.

Each commit is self-contained, documents root cause and impact, and follows the project's `func_rc` / `goto err` conventions.

## Fixes

1. **`p11wrap` returned success (0) on usage errors** — on an unrecognised/missing option, `p11wrap` set `p11wraprc` but the epilog recomputes it from `retcode` (still `rc_ok`), so it printed "Key wrapping operations succeeded" and returned `EX_OK`. Now sets `retcode`, matching `p11unwrap`/`p11rewrap`; returns `EX_USAGE`.

2. **`p11req` / `p11mkcert` returned success (0) when generation failed** — when `pkcs11_create_X509_REQ()` / `pkcs11_create_X509()` returned `NULL`, both tools printed an error but left `retcode = rc_ok`, exiting 0 with no output file. Now set `rc_error_other_error`. (Reproducible with a DSA key + `-H sha384`: no signature OID for SHA-384.)

3. **`p11cp` / `p11mv` ignored errors and mis-checked prefixed destinations** — (a) both tools discarded the return of `pkcs11_cp_objects()` / `pkcs11_mv_objects()`, so every failure still exited 0; now captured into `retcode`. (b) The destination-exists check for typed destinations (`prvk/`, `pubk/`, `seck/`, `cert/`) passed the still-prefixed `dest` to the `*_exists()` helpers (searching CKA_LABEL verbatim, e.g. literal `"seck/foo"`), so the guard never matched and the object was silently duplicated; now passes the prefix-stripped `destlabel`.

4. **Read `CKA_ID` (not `CKA_LABEL`) for `oid` in `pkcs11_change_object_attributes`** — copy-paste defect in the interactive confirmation branch (correct reference is `pkcs11_rm.c`). A label-less (id-only) object was shown as `UNLABELLED_OBJECT` in the confirmation prompt instead of `id/{hex}`. Display only; set logic unaffected.

5. **Repair extended object-filter (search template) parsing** — the documented extended filter syntax (e.g. `p11ls seck/id/{cafe}+CKA_ENCRYPT/{01}`) was broken by three C undefined-behaviour defects in `lib/pkcs11_template.c`: an uninitialised `attr_value` read on the first loop iteration; and single-`char` `strsep()` delimiters (`&plus_delim`) where `strsep()` expects a NUL-terminated delimiter *string*, reading past the byte into adjacent stack memory. Fixed by initialising `attr_value = NULL` and using proper `"/"` / `"+"` delimiter strings.

6. **Reset `parsing_envelope` parser state before each parse** — the bison wrappedkey parser leaks its file-scope nested-envelope depth counter when a parse errors inside an `envelope()` production (the `--parsing_envelope` action is skipped by `YYERROR`), so a subsequent valid envelope parse in the same process wrongly trips the "nested envelope not allowed" guard. Harmless in the shipped tools (one parse per process) but a genuine latent state leak; now reset to 0 at both parse entry points.

## Notes

- Targets `master`, per `docs/CONTRIBUTING.md`.
- Tests for these fixes are part of the upcoming test-framework PR; this PR intentionally contains only the fixes so they can land independently.
